### PR TITLE
feat: solid testing infrastructure — shared entity-config-tester & e2e scripts

### DIFF
--- a/utils/testing/entity-config-tester.ts
+++ b/utils/testing/entity-config-tester.ts
@@ -133,15 +133,16 @@ export function createEntityConfigTests(
 
     // ── processReqForExport ──────────────────────────────────────────────────
     if (expectedExportJoins !== undefined) {
-      it('processReqForExport should mutate request joins and call innerFunc', () => {
+      it('processReqForExport should mutate request joins and call innerFunc', async () => {
+        expect(config.exporter).toBeDefined();
         expect(config.exporter!.processReqForExport).toBeInstanceOf(Function);
 
         const mockReq = {
           options: { query: { join: {} } },
         } as unknown as CrudRequest;
-        const mockInner = jest.fn((req: CrudRequest) => req as any);
+        const mockInner = jest.fn((req: CrudRequest) => Promise.resolve(req) as any);
 
-        config.exporter!.processReqForExport!(mockReq, mockInner);
+        await config.exporter!.processReqForExport!(mockReq, mockInner);
 
         expect(mockInner).toHaveBeenCalledWith(mockReq);
         expect(mockReq.options.query.join).toEqual(expectedExportJoins);
@@ -151,6 +152,7 @@ export function createEntityConfigTests(
     // ── getExportHeaders ─────────────────────────────────────────────────────
     if (expectedExportHeaders !== undefined) {
       it('getExportHeaders should return expected headers', () => {
+        expect(config.exporter).toBeDefined();
         expect(config.exporter!.getExportHeaders).toBeInstanceOf(Function);
 
         const headers = config.exporter!.getExportHeaders!([], undefined, undefined);
@@ -178,6 +180,7 @@ export function createEntityConfigTests(
     // ── getImportDefinition ──────────────────────────────────────────────────
     if (expectedImport !== undefined) {
       it('getImportDefinition should return expected structure', () => {
+        expect(config.exporter).toBeDefined();
         expect(config.exporter!.getImportDefinition).toBeInstanceOf(Function);
 
         const importDef = config.exporter!.getImportDefinition!([]);

--- a/utils/testing/entity-config-tester.ts
+++ b/utils/testing/entity-config-tester.ts
@@ -1,0 +1,208 @@
+import { CrudRequest } from '@dataui/crud';
+import { BaseEntityModuleOptions } from '@shared/base-entity/interface';
+
+/**
+ * Options that describe the expected shape of an entity config.
+ * All fields are optional — only the assertions for the fields you provide are run.
+ */
+export interface EntityConfigTestOptions {
+  /** The entity class the config should declare. */
+  entity: Function;
+
+  /**
+   * Expected `config.query.join` value.
+   * When provided, asserts that `config.query` is defined and its `join` deeply equals this value.
+   */
+  expectedJoins?: Record<string, { eager?: boolean } | object>;
+
+  /**
+   * Expected joins that `processReqForExport` sets on the request.
+   * When provided, calls `processReqForExport` with a mock request and asserts the joins.
+   * Supports `expect.objectContaining` style if you pass `expect.objectContaining(...)` as value.
+   */
+  expectedExportJoins?: Record<string, { eager?: boolean } | object> | ReturnType<typeof expect.objectContaining>;
+
+  /**
+   * Assertions for `getExportHeaders`.
+   * - `count`: exact number of headers returned
+   * - `includes`: one or more headers that must appear (uses `arrayContaining`)
+   * - `first`: the very first header must equal this value exactly
+   */
+  expectedExportHeaders?: {
+    count?: number;
+    includes?: Array<{ value: string | Function; label: string }>;
+    first?: { value: string | Function; label: string };
+  };
+
+  /**
+   * Assertions for `getImportDefinition`.
+   * - `importFieldsCount`: exact number of importFields
+   * - `specialFieldsCount`: exact number of specialFields
+   * - `hardCodedFieldsCount`: exact number of hardCodedFields
+   * - `beforeSave`: expected beforeSave function
+   */
+  expectedImport?: {
+    importFieldsCount?: number;
+    specialFieldsCount?: number;
+    hardCodedFieldsCount?: number;
+    beforeSave?: Function;
+  };
+
+  /**
+   * Inject extra `describe` blocks after the auto-generated assertions.
+   * Use this for config-specific logic (custom service methods, unique edge cases, etc.).
+   *
+   * @example
+   * customTests: () => {
+   *   describe('calcMyLogic', () => {
+   *     it('does the thing', () => { ... });
+   *   });
+   * }
+   */
+  customTests?: () => void;
+}
+
+/**
+ * createEntityConfigTests
+ *
+ * Generates a standard Jest `describe` block that validates a NestJS entity config object
+ * exported from a `*.config.ts` file.
+ *
+ * Tests auto-generated from `options`:
+ *  - entity class identity check
+ *  - query.join shape (when `expectedJoins` provided)
+ *  - exporter presence (when any exporter option is provided)
+ *  - processReqForExport join mutation (when `expectedExportJoins` provided)
+ *  - getExportHeaders return value (when `expectedExportHeaders` provided)
+ *  - getImportDefinition return structure (when `expectedImport` provided)
+ *
+ * Custom tests are appended at the bottom of the describe block via `customTests`.
+ *
+ * @example
+ * // In my-entity.config.spec.ts
+ * import config from '../my-entity.config';
+ * import { MyEntity } from 'src/db/entities/MyEntity.entity';
+ * import { createEntityConfigTests } from '@shared/utils/testing/entity-config-tester';
+ *
+ * createEntityConfigTests('MyEntityConfig', config, {
+ *   entity: MyEntity,
+ *   expectedJoins: { teacher: { eager: false } },
+ *   expectedExportJoins: { teacher: { eager: true } },
+ *   expectedExportHeaders: { count: 4, first: { value: 'teacher.name', label: 'מורה' } },
+ * });
+ */
+export function createEntityConfigTests(
+  name: string,
+  config: BaseEntityModuleOptions,
+  options: EntityConfigTestOptions,
+): void {
+  const {
+    entity,
+    expectedJoins,
+    expectedExportJoins,
+    expectedExportHeaders,
+    expectedImport,
+    customTests,
+  } = options;
+
+  describe(name, () => {
+    // ── entity ──────────────────────────────────────────────────────────────
+    it('should use the correct entity class', () => {
+      expect(config.entity).toBe(entity);
+    });
+
+    // ── query.join ───────────────────────────────────────────────────────────
+    if (expectedJoins !== undefined) {
+      it('should have correct query.join configuration', () => {
+        expect(config.query).toBeDefined();
+        expect(config.query!.join).toEqual(expectedJoins);
+      });
+    }
+
+    // ── exporter ─────────────────────────────────────────────────────────────
+    const hasExporterAssertions =
+      expectedExportJoins !== undefined ||
+      expectedExportHeaders !== undefined ||
+      expectedImport !== undefined;
+
+    if (hasExporterAssertions) {
+      it('should have an exporter defined', () => {
+        expect(config.exporter).toBeDefined();
+      });
+    }
+
+    // ── processReqForExport ──────────────────────────────────────────────────
+    if (expectedExportJoins !== undefined) {
+      it('processReqForExport should mutate request joins and call innerFunc', () => {
+        expect(config.exporter!.processReqForExport).toBeInstanceOf(Function);
+
+        const mockReq = {
+          options: { query: { join: {} } },
+        } as unknown as CrudRequest;
+        const mockInner = jest.fn((req: CrudRequest) => req as any);
+
+        config.exporter!.processReqForExport!(mockReq, mockInner);
+
+        expect(mockInner).toHaveBeenCalledWith(mockReq);
+        expect(mockReq.options.query.join).toEqual(expectedExportJoins);
+      });
+    }
+
+    // ── getExportHeaders ─────────────────────────────────────────────────────
+    if (expectedExportHeaders !== undefined) {
+      it('getExportHeaders should return expected headers', () => {
+        expect(config.exporter!.getExportHeaders).toBeInstanceOf(Function);
+
+        const headers = config.exporter!.getExportHeaders!([], undefined, undefined);
+
+        expect(Array.isArray(headers)).toBe(true);
+
+        if (expectedExportHeaders.count !== undefined) {
+          expect(headers).toHaveLength(expectedExportHeaders.count);
+        }
+
+        if (expectedExportHeaders.first !== undefined) {
+          expect(headers[0]).toEqual(expectedExportHeaders.first);
+        }
+
+        if (expectedExportHeaders.includes !== undefined && expectedExportHeaders.includes.length > 0) {
+          expect(headers).toEqual(
+            expect.arrayContaining(
+              expectedExportHeaders.includes.map(h => expect.objectContaining(h)),
+            ),
+          );
+        }
+      });
+    }
+
+    // ── getImportDefinition ──────────────────────────────────────────────────
+    if (expectedImport !== undefined) {
+      it('getImportDefinition should return expected structure', () => {
+        expect(config.exporter!.getImportDefinition).toBeInstanceOf(Function);
+
+        const importDef = config.exporter!.getImportDefinition!([]);
+
+        if (expectedImport.importFieldsCount !== undefined) {
+          expect(importDef.importFields).toHaveLength(expectedImport.importFieldsCount);
+        }
+
+        if (expectedImport.specialFieldsCount !== undefined) {
+          expect(importDef.specialFields).toHaveLength(expectedImport.specialFieldsCount);
+        }
+
+        if (expectedImport.hardCodedFieldsCount !== undefined) {
+          expect(importDef.hardCodedFields).toHaveLength(expectedImport.hardCodedFieldsCount);
+        }
+
+        if (expectedImport.beforeSave !== undefined) {
+          expect(importDef.beforeSave).toBe(expectedImport.beforeSave);
+        }
+      });
+    }
+
+    // ── custom tests ─────────────────────────────────────────────────────────
+    if (customTests) {
+      customTests();
+    }
+  });
+}

--- a/utils/testing/run-e2e-tests.sh
+++ b/utils/testing/run-e2e-tests.sh
@@ -5,5 +5,14 @@
 # endpoints.env lives at:   server/helpers/endpoints.env  (../../../helpers/)
 # runner lives alongside:   server/shared/utils/testing/test-all-endpoints-runner.sh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "$SCRIPT_DIR/../../../helpers/endpoints.env"
+
+ENDPOINTS_ENV_FILE="${ENDPOINTS_ENV_FILE:-$SCRIPT_DIR/../../../helpers/endpoints.env}"
+
+if [ ! -r "$ENDPOINTS_ENV_FILE" ]; then
+    echo "Error: endpoints env file '$ENDPOINTS_ENV_FILE' does not exist or is not readable." >&2
+    echo "Set ENDPOINTS_ENV_FILE to override the default path." >&2
+    exit 1
+fi
+
+. "$ENDPOINTS_ENV_FILE"
 exec "$SCRIPT_DIR/test-all-endpoints-runner.sh"

--- a/utils/testing/run-e2e-tests.sh
+++ b/utils/testing/run-e2e-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Runs curl-based endpoint smoke tests against a running backend.
+# Requires BACKEND_URL and ADMIN_USER env vars, or uses defaults.
+# Called from: server/shared/utils/testing/run-e2e-tests.sh
+# endpoints.env lives at:   server/helpers/endpoints.env  (../../../helpers/)
+# runner lives alongside:   server/shared/utils/testing/test-all-endpoints-runner.sh
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/../../../helpers/endpoints.env"
+exec "$SCRIPT_DIR/test-all-endpoints-runner.sh"

--- a/utils/testing/test-all-endpoints-runner.sh
+++ b/utils/testing/test-all-endpoints-runner.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# test-all-endpoints-runner.sh
+#
+# Shared backend API smoke test runner.
+# Reads all configuration from environment variables — no hardcoded values.
+#
+# Required env vars:
+#   ENDPOINTS   — space-separated list of endpoint names to test
+#                 e.g. "user student att_report"
+#
+# Optional env vars:
+#   BACKEND_URL — base URL of the backend (default: http://localhost:3001)
+#   ADMIN_USER  — credentials as "username:password"
+#                 (default: admin_user:admin_password)
+
+BACKEND_URL="${BACKEND_URL:-http://localhost:3001}"
+ADMIN_USER="${ADMIN_USER:-admin_user:admin_password}"
+
+USERNAME="${ADMIN_USER%%:*}"
+PASSWORD="${ADMIN_USER#*:}"
+
+if [ -z "$ENDPOINTS" ]; then
+  echo "ERROR: ENDPOINTS environment variable is not set."
+  echo "Set it to a space-separated list of endpoint names before calling this script."
+  echo "Example: ENDPOINTS=\"user student att_report\" ./test-all-endpoints-runner.sh"
+  exit 1
+fi
+
+echo "============================================"
+echo "API Endpoints Smoke Test - $(date)"
+echo "Backend: $BACKEND_URL"
+echo "User: $USERNAME"
+echo "============================================"
+echo ""
+
+# Login and get cookie
+COOKIE_FILE="$(mktemp /tmp/e2e-cookies-XXXXXX.txt)"
+trap 'rm -f "$COOKIE_FILE"' EXIT
+
+echo "Step 1: Login..."
+LOGIN_RESPONSE="$(curl -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}" \
+  -c "$COOKIE_FILE" -s \
+  "$BACKEND_URL/auth/login")"
+
+if echo "$LOGIN_RESPONSE" | grep -q '"success":true'; then
+  echo "  ✓ Login successful"
+else
+  echo "  ✗ Login failed"
+  echo "  Response: $LOGIN_RESPONSE"
+  exit 1
+fi
+
+echo ""
+echo "Step 2: Testing entity endpoints..."
+echo ""
+
+PASSED=0
+FAILED=0
+FAILED_DETAILS=""
+
+for ENDPOINT in $ENDPOINTS; do
+  printf "  %-45s ... " "$ENDPOINT"
+
+  RESP_FILE="$(mktemp /tmp/e2e-resp-XXXXXX.json)"
+  HTTP_CODE="$(curl \
+    -b "$COOKIE_FILE" \
+    -s \
+    -o "$RESP_FILE" \
+    -w "%{http_code}" \
+    "$BACKEND_URL/$ENDPOINT")"
+
+  if [ "$HTTP_CODE" = "200" ]; then
+    printf "✓ OK\n"
+    PASSED=$((PASSED + 1))
+  else
+    printf "✗ FAILED (HTTP %s)\n" "$HTTP_CODE"
+    FAILED=$((FAILED + 1))
+    FAILED_DETAILS="${FAILED_DETAILS}
+--- $ENDPOINT (HTTP $HTTP_CODE) ---
+$(cat "$RESP_FILE")
+"
+  fi
+  rm -f "$RESP_FILE"
+done
+
+echo ""
+echo "============================================"
+echo "  PASSED: $PASSED"
+echo "  FAILED: $FAILED"
+echo "============================================"
+
+if [ "$FAILED" -gt 0 ]; then
+  echo ""
+  echo "Failed endpoint details:"
+  echo "$FAILED_DETAILS"
+fi
+
+exit "$FAILED"

--- a/utils/testing/test-all-endpoints-runner.sh
+++ b/utils/testing/test-all-endpoints-runner.sh
@@ -2,7 +2,8 @@
 # test-all-endpoints-runner.sh
 #
 # Shared backend API smoke test runner.
-# Reads all configuration from environment variables — no hardcoded values.
+# Reads configuration from environment variables, with defaults for optional
+# values when they are unset.
 #
 # Required env vars:
 #   ENDPOINTS   — space-separated list of endpoint names to test
@@ -38,9 +39,10 @@ COOKIE_FILE="$(mktemp /tmp/e2e-cookies-XXXXXX.txt)"
 trap 'rm -f "$COOKIE_FILE"' EXIT
 
 echo "Step 1: Login..."
+LOGIN_BODY="$(python3 -c "import json,sys; print(json.dumps({'username':sys.argv[1],'password':sys.argv[2]}))" "$USERNAME" "$PASSWORD")"
 LOGIN_RESPONSE="$(curl -X POST \
   -H "Content-Type: application/json" \
-  -d "{\"username\":\"$USERNAME\",\"password\":\"$PASSWORD\"}" \
+  -d "$LOGIN_BODY" \
   -c "$COOKIE_FILE" -s \
   "$BACKEND_URL/auth/login")"
 


### PR DESCRIPTION
## Summary

Adds a centralised testing layer to the shared server utilities, and removes dead code.

### New: `utils/testing/entity-config-tester.ts`
A reusable Jest factory (`createEntityConfigTests`) that generates a standard `describe` block for validating any NestJS entity config object. Tests auto-generated per options:
- entity class identity
- `query.join` shape
- exporter presence
- `processReqForExport` join mutation
- `getExportHeaders` return value
- `getImportDefinition` structure

### New: e2e scripts
- `utils/testing/run-e2e-tests.sh` — thin wrapper for per-project usage
- `utils/testing/test-all-endpoints-runner.sh` — curl-based smoke test runner (sources `endpoints.env` from the calling project)

### Refactoring / cleanup
- Remove `getExportName()` from `BaseEntityService` (was just returning `getName()`) and update controller spec accordingly
- Remove unused `optionalInFilter` / `recordToMap` from `reportData.util.ts`
- Remove `reportData.util.spec.ts` (its functions are simple pure utilities; coverage via integration)
- Simplify `DataToExcelReportGenerator` type parameters (remove redundant second generic)

### Breaking changes
- `BaseEntityService.getExportName()` removed — callers should use `getName()` directly