### PR TITLE
Add ApiEnterID support to MockCall and YemotScenarioRunner

### DIFF
--- a/utils/yemot/testing/mock-call.ts
+++ b/utils/yemot/testing/mock-call.ts
@@ -18,6 +18,7 @@ export interface MockCallOptions {
   ApiDID?: string;
   ApiPhone?: string;
   ApiCallId?: string;
+  ApiEnterID?: string;
   did?: string;
   phone?: string;
   callId?: string;
@@ -62,6 +63,7 @@ export class MockCall {
   ApiDID: string;
   ApiPhone: string;
   ApiCallId: string;
+  ApiEnterID?: string;
 
   private inputs: (string | false)[] = [];
   private idx = 0;
@@ -80,6 +82,7 @@ export class MockCall {
     this.ApiDID = opts.ApiDID || opts.did || '';
     this.ApiPhone = opts.ApiPhone || opts.phone || '';
     this.ApiCallId = opts.ApiCallId || opts.callId || '';
+    this.ApiEnterID = opts.ApiEnterID;
   }
 
   /** Set the ordered list of inputs that read() will return. */

--- a/utils/yemot/testing/scenario-runner.ts
+++ b/utils/yemot/testing/scenario-runner.ts
@@ -23,9 +23,11 @@ export type YemotHandlerConstructor = new (
  */
 export class YemotScenarioRunner {
   private HandlerClass: YemotHandlerConstructor;
+  private apiEnterId?: string;
 
-  constructor(HandlerClass: YemotHandlerConstructor) {
+  constructor(HandlerClass: YemotHandlerConstructor, apiEnterId?: string) {
     this.HandlerClass = HandlerClass;
+    this.apiEnterId = apiEnterId;
   }
 
   /**
@@ -129,6 +131,7 @@ export class YemotScenarioRunner {
       ApiDID: '099999999',
       ApiPhone: '0501234567',
       ApiCallId: 'test-call-1',
+      ApiEnterID: this.apiEnterId,
     });
 
     // Extract user responses from ask_input and confirmation steps


### PR DESCRIPTION
## Summary

Add `ApiEnterID` support to the shared Yemot testing utilities, following the existing pattern for `ApiDID`, `ApiPhone`, and `ApiCallId`.

## Changes

### `mock-call.ts`
- Add `ApiEnterID?: string` to `MockCallOptions`
- Add `ApiEnterID?: string` property to `MockCall` class
- Set `this.ApiEnterID = opts.ApiEnterID` in constructor

### `scenario-runner.ts`
- Add optional `apiEnterId?: string` parameter to `YemotScenarioRunner` constructor
- Pass `ApiEnterID: this.apiEnterId` to `MockCall` in `createMockCall()`

## Why

`ApiEnterID` is a standard field on the yemot-router2 `Call` object. Currently, `event-management-nra`'s handler uses `call.ApiEnterID` for class celebrations (999999) and secret tatnikit (4451114) flows, but the shared testing utilities didn't support it — requiring a project-specific `CustomScenarioRunner` subclass that duplicated the entire `run()` method.

With this change, any project can test `ApiEnterID`-based flows by simply passing the value to the runner constructor:

```ts
const runner = new YemotScenarioRunner(YemotHandlerService, '999999');
```

## Verification

All 46 event-management-nra tests pass with the shared runner (no `CustomScenarioRunner` needed):

```
Tests: 46 passed, 46 total
```