### PR TITLE
fix(tests): await dispatchHangup/dispatchSend in yemot handler specs

### DIFF
--- a/utils/yemot/testing/__tests__/scenario-runner.spec.ts
+++ b/utils/yemot/testing/__tests__/scenario-runner.spec.ts
@@ -11,7 +11,7 @@ class FakeHandler extends BaseYemotHandlerService {
     const name = await this.askForInput('What is your name?', { max_digits: 10 });
     const age = await this.askForInput('What is your age?', { max_digits: 2 });
     const confirmed = await this.askForInput('Confirm? 1=yes, 2=no', { max_digits: 1 });
-    this.hangupWithMessage(`Thank you ${name}, age ${age}, confirmed: ${confirmed}`);
+    await this.hangupWithMessage(`Thank you ${name}, age ${age}, confirmed: ${confirmed}`);
   }
 }
 
@@ -71,7 +71,7 @@ describe('YemotScenarioRunner', () => {
     class EarlyHangupHandler extends BaseYemotHandlerService {
       override async processCall(): Promise<void> {
         await this.getUserByDidPhone();
-        this.hangupWithMessage('Goodbye early');
+        await this.hangupWithMessage('Goodbye early');
       }
     }
 

--- a/utils/yemot/v2/__tests__/base-yemot-handler.service.spec.ts
+++ b/utils/yemot/v2/__tests__/base-yemot-handler.service.spec.ts
@@ -316,7 +316,7 @@ describe('BaseYemotHandlerService', () => {
 
   describe('hangupWithMessage', () => {
     it('should log conversation step with stepType: hangup_message', async () => {
-      handler.testHangupWithMessage('Goodbye');
+      await handler.testHangupWithMessage('Goodbye');
 
       expect(mockCallTracker.logConversationStep).toHaveBeenCalledWith(
         'test-call-123',
@@ -326,8 +326,8 @@ describe('BaseYemotHandlerService', () => {
       );
     });
 
-    it('should send message via call.id_list_message()', () => {
-      handler.testHangupWithMessage('Test message');
+    it('should send message via call.id_list_message()', async () => {
+      await handler.testHangupWithMessage('Test message');
 
       expect(mockCall.id_list_message).toHaveBeenCalledWith(
         [{ type: 'text', data: 'Test message' }],
@@ -335,14 +335,14 @@ describe('BaseYemotHandlerService', () => {
       );
     });
 
-    it('should call call.hangup()', () => {
-      handler.testHangupWithMessage('Ending call');
+    it('should call call.hangup()', async () => {
+      await handler.testHangupWithMessage('Ending call');
 
       expect(mockCall.hangup).toHaveBeenCalled();
     });
 
-    it('should use prependToNextAction: true', () => {
-      handler.testHangupWithMessage('Message');
+    it('should use prependToNextAction: true', async () => {
+      await handler.testHangupWithMessage('Message');
 
       expect(mockCall.id_list_message).toHaveBeenCalledWith(
         expect.anything(),
@@ -413,8 +413,8 @@ describe('BaseYemotHandlerService', () => {
   });
 
   describe('sendMessage', () => {
-    it('should log conversation step (send_message)', () => {
-      handler.testSendMessage('Info message');
+    it('should log conversation step (send_message)', async () => {
+      await handler.testSendMessage('Info message');
 
       expect(mockCallTracker.logConversationStep).toHaveBeenCalledWith(
         'test-call-123',
@@ -424,8 +424,8 @@ describe('BaseYemotHandlerService', () => {
       );
     });
 
-    it('should call call.id_list_message()', () => {
-      handler.testSendMessage('Notification');
+    it('should call call.id_list_message()', async () => {
+      await handler.testSendMessage('Notification');
 
       expect(mockCall.id_list_message).toHaveBeenCalledWith(
         [{ type: 'text', data: 'Notification' }],
@@ -433,8 +433,8 @@ describe('BaseYemotHandlerService', () => {
       );
     });
 
-    it('should use prependToNextAction: true', () => {
-      handler.testSendMessage('Message');
+    it('should use prependToNextAction: true', async () => {
+      await handler.testSendMessage('Message');
 
       expect(mockCall.id_list_message).toHaveBeenCalledWith(
         expect.anything(),


### PR DESCRIPTION
Both dispatchHangup and dispatchSend are async; test callbacks that called them without await caused unhandled promise rejections.