### PR TITLE
refactor: add hungUp flag to BaseYemotHandlerService

### DIFF
--- a/utils/yemot/v2/yemot-router.service.ts
+++ b/utils/yemot/v2/yemot-router.service.ts
@@ -92,6 +92,8 @@ export class YemotRouterService {
 export class BaseYemotHandlerService {
   protected readonly logger = logger;
   protected user: User;
+  /** True once hangupWithMessage() has been called. */
+  hungUp = false;
 
   constructor(
     @InjectDataSource() protected dataSource: DataSource,
@@ -144,6 +146,7 @@ export class BaseYemotHandlerService {
     this.logger.log(`Hanging up with message: ${message}`);
     this.callTracker.logConversationStep(this.call.callId, message, undefined, 'hangup_message');
     this.call.id_list_message([{ type: 'text', data: message }], { prependToNextAction: true });
+    this.hungUp = true;
     this.call.hangup();
   }
 
@@ -167,6 +170,7 @@ export class BaseYemotHandlerService {
     const messageText = messageObj.type === 'file' ? `[File: ${messageObj.data}]` : messageObj.data;
     await this.callTracker.logConversationStep(this.call.callId, messageText, undefined, 'hangup_message');
     this.call.id_list_message([messageObj], { prependToNextAction: true });
+    this.hungUp = true;
     this.call.hangup();
   }
 


### PR DESCRIPTION
## Summary

Add a `hungUp` boolean flag to `BaseYemotHandlerService` that is set to `true` in `hangupWithMessage()` and `hangupWithMessageByKey()` before calling `this.call.hangup()`.

## Why

Handler subclasses that wrap `finishSavingReport()` in a try/catch need to distinguish between:
- A normal hangup (exit error from `hangup()` inside `finishSavingReport()`) — should re-throw
- An actual save failure — should show "Data not saved" message

Previously the catch block checked error name strings (`ExitError` / `MockExitError`), which was fragile and referenced test-specific class names. The `hungUp` flag provides a clean semantic check: `if (this.hungUp) throw error;`

## Changes

- `BaseYemotHandlerService`: added `hungUp = false` property
- `hangupWithMessage()`: sets `this.hungUp = true` before `this.call.hangup()`
- `hangupWithMessageByKey()`: sets `this.hungUp = true` before `this.call.hangup()`

## Testing

All 223 yemot-related tests pass (59 handler tests + 151 shared tests + 13 base handler tests).