### PR TITLE
feat(report): add Mp3 file format to CommonFileFormat

### DIFF
--- a/utils/report/__tests__/buffer-to-mp3.generator.spec.ts
+++ b/utils/report/__tests__/buffer-to-mp3.generator.spec.ts
@@ -1,0 +1,18 @@
+import { BufferToMp3ReportGenerator } from "../buffer-to-mp3.generator";
+import { CommonFileFormat } from "../types";
+
+const generator = new BufferToMp3ReportGenerator(() => 'test');
+
+describe('BufferToMp3ReportGenerator', () => {
+    it('should have Mp3 as its file format', () => {
+        expect(generator.fileFormat).toBe(CommonFileFormat.Mp3);
+    });
+
+    it('should return the input buffer unchanged', async () => {
+        const data = Buffer.from('fake-mp3-bytes');
+
+        const result = await generator.getFileBuffer(data);
+
+        expect(result).toEqual(data);
+    });
+});

--- a/utils/report/__tests__/report.util.spec.ts
+++ b/utils/report/__tests__/report.util.spec.ts
@@ -30,6 +30,7 @@ describe('report.util', () => {
             expect(getFileExtension(CommonFileFormat.Json)).toBe('json');
             expect(getFileExtension(CommonFileFormat.Zip)).toBe('zip');
             expect(getFileExtension(CommonFileFormat.Html)).toBe('html');
+            expect(getFileExtension(CommonFileFormat.Mp3)).toBe('mp3');
         });
     });
 
@@ -40,6 +41,7 @@ describe('report.util', () => {
             expect(getFileType(CommonFileFormat.Json)).toBe('application/json');
             expect(getFileType(CommonFileFormat.Zip)).toBe('application/zip');
             expect(getFileType(CommonFileFormat.Html)).toBe('text/html');
+            expect(getFileType(CommonFileFormat.Mp3)).toBe('audio/mpeg');
         })
     });
 

--- a/utils/report/buffer-to-mp3.generator.ts
+++ b/utils/report/buffer-to-mp3.generator.ts
@@ -1,0 +1,10 @@
+import { BaseReportGenerator } from "./report.generators";
+import { CommonFileFormat } from "./types";
+
+export class BufferToMp3ReportGenerator extends BaseReportGenerator<Buffer, Buffer> {
+    fileFormat: CommonFileFormat = CommonFileFormat.Mp3;
+
+    async getFileBuffer(data: Buffer): Promise<Buffer> {
+        return data;
+    }
+}

--- a/utils/report/report.util.ts
+++ b/utils/report/report.util.ts
@@ -33,6 +33,8 @@ export function getFileType(format: CommonFileFormat): string {
             return 'application/zip';
         case CommonFileFormat.Html:
             return 'text/html';
+        case CommonFileFormat.Mp3:
+            return 'audio/mpeg';
     }
 }
 
@@ -54,6 +56,8 @@ export function getFileExtension(format: CommonFileFormat) {
             return 'zip';
         case CommonFileFormat.Html:
             return 'html';
+        case CommonFileFormat.Mp3:
+            return 'mp3';
     }
 
 }

--- a/utils/report/types.ts
+++ b/utils/report/types.ts
@@ -12,6 +12,7 @@ export enum CommonFileFormat {
     Json,
     Zip,
     Html,
+    Mp3,
 };
 
 export interface CommonReportData<T = any> {


### PR DESCRIPTION
Lets the common base64 file-response helper (generateCommonFileResponse) be reused for audio downloads (e.g. ElevenLabs-generated narration), the same way it's already used for Excel/PDF/JSON/Zip/Html reports.