### PR TITLE
Add generic S3 utility service

### DIFF
--- a/utils/s3/__tests__/s3.service.spec.ts
+++ b/utils/s3/__tests__/s3.service.spec.ts
@@ -1,0 +1,155 @@
+import { Readable } from "stream";
+import { S3Service } from "../s3.service";
+
+describe("S3Service", () => {
+    let service: S3Service;
+    let mockS3Client: any;
+
+    beforeEach(() => {
+        mockS3Client = {
+            send: jest.fn(),
+        };
+        service = new S3Service(mockS3Client);
+    });
+
+    describe("uploadFile", () => {
+        it("should send a PutObjectCommand with the correct params", async () => {
+            mockS3Client.send.mockResolvedValue({});
+            const body = Buffer.from("hello world");
+
+            await service.uploadFile("my-bucket", "path/to/file.txt", body, "text/plain");
+
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: {
+                        Bucket: "my-bucket",
+                        Key: "path/to/file.txt",
+                        Body: body,
+                        ContentType: "text/plain",
+                    },
+                })
+            );
+        });
+
+        it("should throw a wrapped error when the upload fails", async () => {
+            mockS3Client.send.mockRejectedValue(new Error("Network error"));
+
+            await expect(
+                service.uploadFile("my-bucket", "path/to/file.txt", Buffer.from("data"))
+            ).rejects.toThrow("S3 error: Network error");
+        });
+    });
+
+    describe("getFileStream", () => {
+        it("should send a GetObjectCommand and return the response body", async () => {
+            const bodyStream = Readable.from([Buffer.from("chunk")]);
+            mockS3Client.send.mockResolvedValue({ Body: bodyStream });
+
+            const result = await service.getFileStream("my-bucket", "path/to/file.txt");
+
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: { Bucket: "my-bucket", Key: "path/to/file.txt" },
+                })
+            );
+            expect(result).toBe(bodyStream);
+        });
+
+        it("should throw a wrapped error when the fetch fails", async () => {
+            mockS3Client.send.mockRejectedValue(new Error("Not found"));
+
+            await expect(service.getFileStream("my-bucket", "missing.txt")).rejects.toThrow(
+                "S3 error: Not found"
+            );
+        });
+    });
+
+    describe("getFileBuffer", () => {
+        it("should resolve to the concatenated buffer across multiple chunks", async () => {
+            const bodyStream = Readable.from([Buffer.from("hello "), Buffer.from("world")]);
+            mockS3Client.send.mockResolvedValue({ Body: bodyStream });
+
+            const result = await service.getFileBuffer("my-bucket", "path/to/file.txt");
+
+            expect(result).toEqual(Buffer.from("hello world"));
+        });
+
+        it("should throw a wrapped error when the stream emits an error", async () => {
+            const bodyStream = new Readable({
+                read() {
+                    this.emit("error", new Error("Stream broke"));
+                },
+            });
+            mockS3Client.send.mockResolvedValue({ Body: bodyStream });
+
+            await expect(service.getFileBuffer("my-bucket", "path/to/file.txt")).rejects.toThrow(
+                "S3 error: Stream broke"
+            );
+        });
+
+        it("should throw a wrapped error when the underlying send call fails", async () => {
+            mockS3Client.send.mockRejectedValue(new Error("Timeout"));
+
+            await expect(service.getFileBuffer("my-bucket", "path/to/file.txt")).rejects.toThrow(
+                "S3 error: Timeout"
+            );
+        });
+    });
+
+    describe("listFiles", () => {
+        it("should send a ListObjectsV2Command with bucket and prefix", async () => {
+            mockS3Client.send.mockResolvedValue({ Contents: [] });
+
+            await service.listFiles("my-bucket", "some/prefix");
+
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: { Bucket: "my-bucket", Prefix: "some/prefix" },
+                })
+            );
+        });
+
+        it("should omit prefix when not provided", async () => {
+            mockS3Client.send.mockResolvedValue({ Contents: [] });
+
+            await service.listFiles("my-bucket");
+
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: { Bucket: "my-bucket", Prefix: undefined },
+                })
+            );
+        });
+
+        it("should map Contents entries into S3ObjectSummary objects", async () => {
+            const lastModified = new Date("2024-01-01T00:00:00Z");
+            mockS3Client.send.mockResolvedValue({
+                Contents: [
+                    { Key: "file1.txt", Size: 123, LastModified: lastModified, ETag: "\"abc\"" },
+                ],
+            });
+
+            const result = await service.listFiles("my-bucket");
+
+            expect(result).toEqual([
+                { key: "file1.txt", size: 123, lastModified, eTag: "\"abc\"" },
+            ]);
+        });
+
+        it("should return an empty array when Contents is undefined", async () => {
+            mockS3Client.send.mockResolvedValue({});
+
+            const result = await service.listFiles("my-bucket");
+
+            expect(result).toEqual([]);
+        });
+
+        it("should throw a wrapped error when listing fails", async () => {
+            mockS3Client.send.mockRejectedValue(new Error("Access denied"));
+
+            await expect(service.listFiles("my-bucket")).rejects.toThrow(
+                "S3 error: Access denied"
+            );
+        });
+    });
+});

--- a/utils/s3/s3.module.ts
+++ b/utils/s3/s3.module.ts
@@ -1,0 +1,24 @@
+import { Module } from "@nestjs/common";
+import { S3Client } from "@aws-sdk/client-s3";
+import { S3_CLIENT, S3Service } from "./s3.service";
+
+@Module({
+    providers: [
+        {
+            provide: S3_CLIENT,
+            useFactory: (): S3Client =>
+                new S3Client({
+                    endpoint: process.env.S3_ENDPOINT,
+                    region: process.env.S3_REGION ?? "us-east-1",
+                    forcePathStyle: true,
+                    credentials: {
+                        accessKeyId: process.env.S3_ACCESS_KEY_ID,
+                        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+                    },
+                }),
+        },
+        S3Service,
+    ],
+    exports: [S3Service],
+})
+export class S3Module {}

--- a/utils/s3/s3.service.ts
+++ b/utils/s3/s3.service.ts
@@ -1,0 +1,96 @@
+import { Inject, Injectable, Logger } from "@nestjs/common";
+import { GetObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { Readable } from "stream";
+
+export const S3_CLIENT = Symbol("S3_CLIENT");
+
+export interface S3ObjectSummary {
+    key: string;
+    size?: number;
+    lastModified?: Date;
+    eTag?: string;
+}
+
+@Injectable()
+export class S3Service {
+    private readonly logger = new Logger(S3Service.name);
+
+    constructor(@Inject(S3_CLIENT) private readonly s3Client: S3Client) {}
+
+    /**
+     * Upload a file to the given bucket/key
+     */
+    async uploadFile(bucket: string, key: string, body: Buffer, contentType?: string): Promise<void> {
+        try {
+            await this.s3Client.send(new PutObjectCommand({
+                Bucket: bucket,
+                Key: key,
+                Body: body,
+                ContentType: contentType,
+            }));
+        } catch (error) {
+            this.logger.error(`Failed to upload file ${bucket}/${key}: ${error.message}`, error.stack);
+            throw new Error(`S3 error: ${error.message}`);
+        }
+    }
+
+    /**
+     * Fetch a file as a stream, e.g. for playback
+     */
+    async getFileStream(bucket: string, key: string): Promise<Readable> {
+        try {
+            return await this.getObjectStream(bucket, key);
+        } catch (error) {
+            this.logger.error(`Failed to get file stream ${bucket}/${key}: ${error.message}`, error.stack);
+            throw new Error(`S3 error: ${error.message}`);
+        }
+    }
+
+    /**
+     * Fetch a file fully buffered into memory
+     */
+    async getFileBuffer(bucket: string, key: string): Promise<Buffer> {
+        try {
+            const stream = await this.getObjectStream(bucket, key);
+            return await streamToBuffer(stream);
+        } catch (error) {
+            this.logger.error(`Failed to get file buffer ${bucket}/${key}: ${error.message}`, error.stack);
+            throw new Error(`S3 error: ${error.message}`);
+        }
+    }
+
+    /**
+     * List files in a bucket, optionally under a prefix
+     */
+    async listFiles(bucket: string, prefix?: string): Promise<S3ObjectSummary[]> {
+        try {
+            const response = await this.s3Client.send(new ListObjectsV2Command({
+                Bucket: bucket,
+                Prefix: prefix,
+            }));
+            return (response.Contents ?? []).map((object) => ({
+                key: object.Key,
+                size: object.Size,
+                lastModified: object.LastModified,
+                eTag: object.ETag,
+            }));
+        } catch (error) {
+            this.logger.error(`Failed to list files in ${bucket} (prefix: ${prefix}): ${error.message}`, error.stack);
+            throw new Error(`S3 error: ${error.message}`);
+        }
+    }
+
+    private async getObjectStream(bucket: string, key: string): Promise<Readable> {
+        const response = await this.s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+        return response.Body as Readable;
+    }
+}
+
+function streamToBuffer(stream: Readable): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        stream.on("data", (chunk) => chunks.push(chunk));
+        stream.on("end", () => resolve(Buffer.concat(chunks)));
+        stream.on("error", reject);
+    });
+}


### PR DESCRIPTION
Wraps @aws-sdk/client-s3 for uploading, downloading (buffer/stream), and listing files against an S3-compatible endpoint configured via env vars. Bucket is passed per call so future flows can each target their own dedicated bucket. Not wired into BaseNraAppModule yet - host apps import S3Module explicitly when they adopt it.