### PR TITLE
Wire S3Module into BaseNraAppModule and add file-store helper

### DIFF
--- a/app/__tests__/base-app.module.spec.ts
+++ b/app/__tests__/base-app.module.spec.ts
@@ -55,6 +55,17 @@ describe('BaseNraAppModule', () => {
       expect(authImport).toBeDefined();
     });
 
+    it('includes S3Module in imports', () => {
+      const { S3Module } = require('@shared/utils/s3/s3.module');
+      const result = BaseNraAppModule.forRoot({
+        entitiesModule: FakeEntitiesModule,
+        yemotHandlerService: FakeYemotHandlerService as any,
+      });
+
+      const imports = result.imports as any[];
+      expect(imports).toContain(S3Module);
+    });
+
     it('applies custom throttlerLimit when provided', () => {
       const result = BaseNraAppModule.forRoot({
         entitiesModule: FakeEntitiesModule,

--- a/app/base-app.module.ts
+++ b/app/base-app.module.ts
@@ -10,6 +10,7 @@ import { DefaultUserInitModule } from '@shared/auth/default-user-init.module';
 import { YemotModule } from '@shared/utils/yemot/v2/yemot.module';
 import { YemotHandlerFactory } from '@shared/utils/yemot/v2/yemot-router.service';
 import { MailSendModule } from '@shared/utils/mail/mail-send.module';
+import { S3Module } from '@shared/utils/s3/s3.module';
 import { getPinoConfig } from '@shared/config/pino.config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -37,6 +38,7 @@ export class BaseNraAppModule {
         ThrottlerModule.forRoot({ ttl: 5, limit: throttlerLimit }),
         TypeOrmModule.forRoot(typeOrmModuleConfig),
         MailSendModule,
+        S3Module,
         options.entitiesModule,
         AuthModule.forRoot({ userInitModule }),
         YemotModule.register(options.yemotHandlerService),

--- a/utils/s3/__tests__/s3-file-store.service.spec.ts
+++ b/utils/s3/__tests__/s3-file-store.service.spec.ts
@@ -1,0 +1,66 @@
+import { S3FileStoreService } from "../s3-file-store.service";
+import { S3Service } from "../s3.service";
+
+describe("S3FileStoreService", () => {
+    let service: S3FileStoreService;
+    let mockS3Service: jest.Mocked<S3Service>;
+
+    const originalBucket = process.env.S3_BUCKET;
+
+    beforeEach(() => {
+        process.env.S3_BUCKET = "my-bucket";
+        mockS3Service = {
+            uploadFile: jest.fn(),
+            getFileBuffer: jest.fn(),
+            deleteFile: jest.fn(),
+        } as unknown as jest.Mocked<S3Service>;
+        service = new S3FileStoreService(mockS3Service);
+    });
+
+    afterAll(() => {
+        process.env.S3_BUCKET = originalBucket;
+    });
+
+    describe("buildKey", () => {
+        it("should build a key namespaced by prefix and id with a unique suffix", () => {
+            const key = service.buildKey("story-voices", 12, "mp3");
+
+            expect(key).toMatch(/^story-voices\/story-voices-12-[0-9a-f-]+\.mp3$/);
+        });
+    });
+
+    describe("upload", () => {
+        it("should delegate to S3Service.uploadFile with the configured bucket", async () => {
+            const body = Buffer.from("hello");
+
+            await service.upload("story-voices/file.mp3", body, "audio/mpeg");
+
+            expect(mockS3Service.uploadFile).toHaveBeenCalledWith(
+                "my-bucket",
+                "story-voices/file.mp3",
+                body,
+                "audio/mpeg",
+            );
+        });
+    });
+
+    describe("download", () => {
+        it("should delegate to S3Service.getFileBuffer with the configured bucket", async () => {
+            const buffer = Buffer.from("data");
+            mockS3Service.getFileBuffer.mockResolvedValue(buffer);
+
+            const result = await service.download("story-voices/file.mp3");
+
+            expect(mockS3Service.getFileBuffer).toHaveBeenCalledWith("my-bucket", "story-voices/file.mp3");
+            expect(result).toBe(buffer);
+        });
+    });
+
+    describe("remove", () => {
+        it("should delegate to S3Service.deleteFile with the configured bucket", async () => {
+            await service.remove("story-voices/file.mp3");
+
+            expect(mockS3Service.deleteFile).toHaveBeenCalledWith("my-bucket", "story-voices/file.mp3");
+        });
+    });
+});

--- a/utils/s3/__tests__/s3.service.spec.ts
+++ b/utils/s3/__tests__/s3.service.spec.ts
@@ -152,4 +152,26 @@ describe("S3Service", () => {
             );
         });
     });
+
+    describe("deleteFile", () => {
+        it("should send a DeleteObjectCommand with the correct params", async () => {
+            mockS3Client.send.mockResolvedValue({});
+
+            await service.deleteFile("my-bucket", "path/to/file.txt");
+
+            expect(mockS3Client.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    input: { Bucket: "my-bucket", Key: "path/to/file.txt" },
+                })
+            );
+        });
+
+        it("should throw a wrapped error when the delete fails", async () => {
+            mockS3Client.send.mockRejectedValue(new Error("Access denied"));
+
+            await expect(service.deleteFile("my-bucket", "path/to/file.txt")).rejects.toThrow(
+                "S3 error: Access denied"
+            );
+        });
+    });
 });

--- a/utils/s3/s3-file-store.service.ts
+++ b/utils/s3/s3-file-store.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@nestjs/common";
+import { randomUUID } from "crypto";
+import { S3Service } from "./s3.service";
+
+/**
+ * Convenience wrapper around S3Service for entities that generate a single file
+ * (e.g. a report or an audio render) and need to store/serve/discard it.
+ * Reads the shared bucket from S3_BUCKET; callers only deal with keys.
+ */
+@Injectable()
+export class S3FileStoreService {
+    constructor(private readonly s3Service: S3Service) {}
+
+    private get bucket(): string {
+        return process.env.S3_BUCKET;
+    }
+
+    /**
+     * Build a unique key under the given prefix, e.g. buildKey("story-voices", 12, "mp3")
+     */
+    buildKey(prefix: string, id: number | string, extension: string): string {
+        return `${prefix}/${prefix}-${id}-${randomUUID()}.${extension}`;
+    }
+
+    async upload(key: string, body: Buffer, contentType?: string): Promise<void> {
+        await this.s3Service.uploadFile(this.bucket, key, body, contentType);
+    }
+
+    async download(key: string): Promise<Buffer> {
+        return this.s3Service.getFileBuffer(this.bucket, key);
+    }
+
+    async remove(key: string): Promise<void> {
+        await this.s3Service.deleteFile(this.bucket, key);
+    }
+}

--- a/utils/s3/s3.module.ts
+++ b/utils/s3/s3.module.ts
@@ -1,7 +1,9 @@
-import { Module } from "@nestjs/common";
+import { Global, Module } from "@nestjs/common";
 import { S3Client } from "@aws-sdk/client-s3";
 import { S3_CLIENT, S3Service } from "./s3.service";
+import { S3FileStoreService } from "./s3-file-store.service";
 
+@Global()
 @Module({
     providers: [
         {
@@ -18,7 +20,8 @@ import { S3_CLIENT, S3Service } from "./s3.service";
                 }),
         },
         S3Service,
+        S3FileStoreService,
     ],
-    exports: [S3Service],
+    exports: [S3Service, S3FileStoreService],
 })
 export class S3Module {}

--- a/utils/s3/s3.service.ts
+++ b/utils/s3/s3.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
-import { GetObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, GetObjectCommand, ListObjectsV2Command, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { Readable } from "stream";
 
 export const S3_CLIENT = Symbol("S3_CLIENT");
@@ -76,6 +76,21 @@ export class S3Service {
             }));
         } catch (error) {
             this.logger.error(`Failed to list files in ${bucket} (prefix: ${prefix}): ${error.message}`, error.stack);
+            throw new Error(`S3 error: ${error.message}`);
+        }
+    }
+
+    /**
+     * Delete a file from the given bucket/key
+     */
+    async deleteFile(bucket: string, key: string): Promise<void> {
+        try {
+            await this.s3Client.send(new DeleteObjectCommand({
+                Bucket: bucket,
+                Key: key,
+            }));
+        } catch (error) {
+            this.logger.error(`Failed to delete file ${bucket}/${key}: ${error.message}`, error.stack);
             throw new Error(`S3 error: ${error.message}`);
         }
     }


### PR DESCRIPTION
Marks S3Module @Global() and registers it in BaseNraAppModule.forRoot() so every host app gets S3Service without per-app wiring. Adds a deleteFile method to S3Service for symmetry with upload/get/list, and a new S3FileStoreService that wraps upload/download/remove against a single S3_BUCKET so entities storing a generated file don't each re-derive the same bucket/key plumbing.