### PR TITLE
fix(yemot): prefix ivr2: scheme on upload/download paths, add deleteFile

### DIFF
--- a/utils/phone/__tests__/yemot-api.service.spec.ts
+++ b/utils/phone/__tests__/yemot-api.service.spec.ts
@@ -186,7 +186,7 @@ describe("YemotApiService", () => {
             expect(mockHttpService.get).toHaveBeenCalledWith(
                 expect.stringContaining("/DownloadFile"),
                 expect.objectContaining({
-                    params: { token: "api-key", path: "ivr/1/5/000.wav" },
+                    params: { token: "api-key", path: "ivr2:/ivr/1/5/000.wav" },
                     responseType: "arraybuffer",
                 })
             );
@@ -198,6 +198,36 @@ describe("YemotApiService", () => {
             mockHttpService.get.mockReturnValue(throwError(() => new Error("Not found")));
 
             await expect(service.downloadFile("api-key", "ivr/1")).rejects.toThrow(
+                "Yemot API error: Not found"
+            );
+        });
+    });
+
+    describe("deleteFile", () => {
+        it("should call FileAction with action=delete and the ivr2-prefixed path", async () => {
+            const mockResponse = {
+                responseStatus: "OK",
+                action: "delete",
+                success: true,
+                reports: [{ what: "ivr2:/1/test.wav", target: null, success: true }],
+            };
+            mockHttpService.get.mockReturnValue(of({ data: mockResponse }));
+
+            const result = await service.deleteFile("api-key", "1/test.wav");
+
+            expect(mockHttpService.get).toHaveBeenCalledWith(
+                expect.stringContaining("/FileAction"),
+                expect.objectContaining({
+                    params: { token: "api-key", action: "delete", what0: "ivr2:/1/test.wav" },
+                })
+            );
+            expect(result).toEqual(mockResponse);
+        });
+
+        it("should throw a wrapped error when the HTTP call fails", async () => {
+            mockHttpService.get.mockReturnValue(throwError(() => new Error("Not found")));
+
+            await expect(service.deleteFile("api-key", "1/test.wav")).rejects.toThrow(
                 "Yemot API error: Not found"
             );
         });

--- a/utils/phone/yemot-api.service.ts
+++ b/utils/phone/yemot-api.service.ts
@@ -134,10 +134,11 @@ export class YemotApiService {
      */
     async uploadFile(apiKey: string, path: string, fileBuffer: Buffer, fileName: string): Promise<any> {
         try {
-            this.logger.log(`Uploading file to Yemot path: ${path}`);
+            const ivrPath = this.toIvrPath(path);
+            this.logger.log(`Uploading file to Yemot path: ${ivrPath}`);
             const formData = new FormData();
             formData.append("token", apiKey);
-            formData.append("path", path);
+            formData.append("path", ivrPath);
             formData.append("file", fileBuffer, { filename: fileName });
 
             const response = await firstValueFrom(
@@ -157,10 +158,11 @@ export class YemotApiService {
      */
     async downloadFile(apiKey: string, path: string): Promise<Buffer> {
         try {
-            this.logger.log(`Downloading file from Yemot path: ${path}`);
+            const ivrPath = this.toIvrPath(path);
+            this.logger.log(`Downloading file from Yemot path: ${ivrPath}`);
             const response = await firstValueFrom(
                 this.httpService.get(`${this.baseUrl}/DownloadFile`, {
-                    params: { token: apiKey, path },
+                    params: { token: apiKey, path: ivrPath },
                     responseType: "arraybuffer",
                 })
             );
@@ -169,5 +171,30 @@ export class YemotApiService {
             this.logger.error(`Failed to download file: ${error.message}`, error.stack);
             throw new Error(`Yemot API error: ${error.message}`);
         }
+    }
+
+    /**
+     * Delete a file from Yemot's IVR2 file system.
+     */
+    async deleteFile(apiKey: string, path: string): Promise<any> {
+        try {
+            const ivrPath = this.toIvrPath(path);
+            this.logger.log(`Deleting Yemot file: ${ivrPath}`);
+            const response = await firstValueFrom(
+                this.httpService.get(`${this.baseUrl}/FileAction`, {
+                    params: { token: apiKey, action: "delete", what0: ivrPath },
+                })
+            );
+            return response.data;
+        } catch (error) {
+            this.logger.error(`Failed to delete file: ${error.message}`, error.stack);
+            throw new Error(`Yemot API error: ${error.message}`);
+        }
+    }
+
+    // Yemot's UploadFile/DownloadFile/FileAction reject bare paths ("path is invalid") - they
+    // require the ivr2: scheme prefix, confirmed against the live API.
+    private toIvrPath(path: string): string {
+        return `ivr2:/${path}`;
     }
 }


### PR DESCRIPTION
Yemot's UploadFile/DownloadFile reject bare paths with "path is invalid"; confirmed against the live API that the ivr2: scheme prefix is required. Also adds deleteFile via the FileAction endpoint (action=delete), used to clean up files uploaded during manual API verification.