### PR TITLE
Add PATCH /profile endpoint for updating phone number

### DIFF
--- a/app/__tests__/app.controller.spec.ts
+++ b/app/__tests__/app.controller.spec.ts
@@ -30,6 +30,7 @@ describe('AppController', () => {
             registerUser: jest.fn().mockRejectedValue(new UnauthorizedException()),
             getProfile: jest.fn().mockResolvedValue({}),
             updateSettings: jest.fn().mockResolvedValue({}),
+            updateProfile: jest.fn().mockResolvedValue({}),
           },
         },
       ],
@@ -165,5 +166,20 @@ describe('AppController', () => {
     const req = { user: { permissions: { admin: true } } } as unknown as AuthenticatedRequest;
 
     await expect(appController.updateSettings(req, { key: 'value' })).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('should update user profile', async () => {
+    const req = { user: { id: 1 } } as unknown as AuthenticatedRequest;
+    const data = { phoneNumber: '0501234567' };
+
+    await appController.updateProfile(req, data);
+
+    expect(authService.updateProfile).toHaveBeenCalledWith(1, data);
+  });
+
+  it('should reject update profile when user id is missing', async () => {
+    const req = { user: { permissions: { admin: true } } } as unknown as AuthenticatedRequest;
+
+    await expect(appController.updateProfile(req, { phoneNumber: '0501234567' })).rejects.toThrow(UnauthorizedException);
   });
 });

--- a/app/app.controller.ts
+++ b/app/app.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpCode,
   UnauthorizedException,
   Post,
+  Patch,
   Request,
   Res,
   UseGuards,
@@ -95,6 +96,16 @@ export class AppController {
       throw new UnauthorizedException();
     }
     return this.authService.updateSettings(userId, data);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('profile')
+  async updateProfile(@Request() req: AuthenticatedRequest, @Body() data: { phoneNumber?: string }) {
+    const userId = getUserIdFromUser(req.user);
+    if (!userId) {
+      throw new UnauthorizedException();
+    }
+    return this.authService.updateProfile(userId, data);
   }
 
   @Get()

--- a/auth/__tests__/auth.service.spec.ts
+++ b/auth/__tests__/auth.service.spec.ts
@@ -424,4 +424,34 @@ describe('AuthService', () => {
             await expect(service.updateSettings(userId, { name: 'new name' })).rejects.toThrowError('User not found');
         });
     });
+
+    describe('updateProfile', () => {
+        it('should update the user phone number', async () => {
+            const userId = 1;
+            const userStub = {
+                id: userId,
+                email: 'test@example.com',
+                name: 'test',
+                permissions: {},
+                phoneNumber: '0500000000',
+            } as any as User;
+
+            const findOneByMock = jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(userStub);
+            const updateMock = jest.spyOn(userRepository, 'update').mockResolvedValue(null);
+
+            const result = await service.updateProfile(userId, { phoneNumber: '0501234567' });
+
+            expect(findOneByMock).toHaveBeenCalledWith({ id: userId });
+            expect(updateMock).toHaveBeenCalledWith(userId, { phoneNumber: '0501234567' });
+            expect(result).toEqual({ success: true });
+        });
+
+        it('should throw an error if the user is not found', async () => {
+            const userId = 1;
+
+            jest.spyOn(userRepository, 'findOneBy').mockResolvedValue(null);
+
+            await expect(service.updateProfile(userId, { phoneNumber: '0501234567' })).rejects.toThrowError('User not found');
+        });
+    });
 });

--- a/auth/auth.service.ts
+++ b/auth/auth.service.ts
@@ -130,4 +130,14 @@ export class AuthService {
     await this.userRepository.update(user.id, { additionalData: user.additionalData });
     return { success: true };
   }
+
+  async updateProfile(userId: number, data: { phoneNumber?: string }) {
+    const user = await this.userRepository.findOneBy({ id: userId });
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    await this.userRepository.update(user.id, { phoneNumber: data.phoneNumber });
+    return { success: true };
+  }
 }


### PR DESCRIPTION
## Summary
- Add `AuthService.updateProfile(userId, { phoneNumber })`, which updates the top-level `phoneNumber` column on the current user's record.
- Add `PATCH /profile` on `AppController`, guarded by `JwtAuthGuard`, using the same `getUserIdFromUser` pattern as the existing `/settings` route.
- This is separate from the existing `POST /settings` endpoint, which only merges data into the `additionalData` JSON blob and never touches top-level columns like `phoneNumber`.
- Uses `userRepository.update()` (not `.save()`) to avoid re-triggering the `@BeforeUpdate hashPassword()` entity listener, which would otherwise double-hash the already-hashed password on every profile update.
- No new validation added — keeps relying on the existing `@MaxLength(11)` constraint already on the `User.phoneNumber` column.

Part of adding a "change phone number in settings" feature. Companion client-side PR: buzz-code/nra-client (same branch name).

## Test plan
- [x] Added unit tests for `AuthService.updateProfile` (success + user-not-found)
- [x] Added unit tests for `AppController.updateProfile` (success + missing user id)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZvK3iL37dFBsmNcdHfkDy)_