### PR TITLE
Add graceful shutdown to avoid dropped requests during deploys

### DIFF
--- a/utils/bootstrap.util.ts
+++ b/utils/bootstrap.util.ts
@@ -69,11 +69,20 @@ export function setupYemotRouter(app: INestApplication) {
   app.use('/yemot/handle-call', yemotRouterSvc.getRouter());
 }
 
+async function gracefulShutdown(app: INestApplication) {
+  await new Promise((resolve) => setTimeout(resolve, 5000)); // let the proxy deregister us first
+  await app.close(); // stops accepting new connections, drains in-flight ones, runs lifecycle hooks
+  process.exit(0);
+}
+
 export async function bootstrapNraApplication(
   module: any,
   options?: Partial<BootstrapOptions>,
 ): Promise<void> {
   const app = await NestFactory.create(module);
+
+  process.on('SIGTERM', () => gracefulShutdown(app));
+  process.on('SIGINT', () => gracefulShutdown(app));
 
   setupApplication(app, {
     swaggerTitle: readPackageJsonName(),


### PR DESCRIPTION
## Summary

Adds graceful shutdown handling to `bootstrapNraApplication` so that in-flight requests are not dropped during deploys and rolling updates.

## Changes

- Added a `gracefulShutdown` function that:
  1. Waits 5 seconds for the proxy to deregister the instance
  2. Calls `app.close()` to stop accepting new connections, drain in-flight ones, and run lifecycle hooks
  3. Exits cleanly with `process.exit(0)`
- Registered `SIGTERM` and `SIGINT` handlers that invoke `gracefulShutdown`

## Why

During Swarm rolling updates or container restarts, the default behavior is immediate process termination, which drops in-flight requests. The 5-second delay gives the reverse proxy time to deregister the instance before `app.close()` drains remaining connections.