### PR TITLE
Add async job queue and scheduler infrastructure

### DIFF
--- a/app/base-app.module.ts
+++ b/app/base-app.module.ts
@@ -11,6 +11,8 @@ import { YemotModule } from '@shared/utils/yemot/v2/yemot.module';
 import { YemotHandlerFactory } from '@shared/utils/yemot/v2/yemot-router.service';
 import { MailSendModule } from '@shared/utils/mail/mail-send.module';
 import { S3Module } from '@shared/utils/s3/s3.module';
+import { JobsModule } from '@shared/utils/jobs/jobs.module';
+import { JobHandler } from '@shared/utils/jobs/job.types';
 import { getPinoConfig } from '@shared/config/pino.config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -22,6 +24,8 @@ export interface BaseNraAppModuleOptions {
   yemotHandlerService: YemotHandlerFactory;
   userInitModule?: Type<any> | DynamicModule;
   throttlerLimit?: number;
+  /** Project-specific async job handlers, registered alongside the shared ones. */
+  jobHandlers?: Type<JobHandler>[];
 }
 
 @Module({})
@@ -39,6 +43,7 @@ export class BaseNraAppModule {
         TypeOrmModule.forRoot(typeOrmModuleConfig),
         MailSendModule,
         S3Module,
+        JobsModule.forRoot({ handlers: options.jobHandlers }),
         options.entitiesModule,
         AuthModule.forRoot({ userInitModule }),
         YemotModule.register(options.yemotHandlerService),

--- a/entities/Job.entity.ts
+++ b/entities/Job.entity.ts
@@ -1,0 +1,77 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { CreatedAtColumn, JsonColumn, UpdatedAtColumn } from '@shared/utils/entity/column-types.util';
+import { IHasUserId } from '@shared/base-entity/interface';
+import { User } from './User.entity';
+
+export type JobStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * A single background job execution. Durable source of truth for the async
+ * worker: rows are claimed by JobWorkerService, run by a registered handler,
+ * and retried with backoff until `maxAttempts`.
+ */
+@Entity('jobs')
+export class Job implements IHasUserId {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('int', { name: 'user_id' })
+  @Index('job_user_id_idx')
+  userId: number;
+
+  @ManyToOne(() => User, { createForeignKeyConstraints: false })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  /** Handler key, e.g. 'user-data-export'. */
+  @Column({ length: 100 })
+  @Index('job_type_idx')
+  type: string;
+
+  @Column({ length: 20, default: 'pending' })
+  @Index('job_status_idx')
+  status: JobStatus;
+
+  @JsonColumn({ nullable: true })
+  payload: Record<string, any>;
+
+  @JsonColumn({ nullable: true })
+  result: Record<string, any>;
+
+  @Column('int', { default: 0 })
+  progress: number;
+
+  @Column('int', { default: 0 })
+  attempts: number;
+
+  @Column('int', { name: 'max_attempts', default: 3 })
+  maxAttempts: number;
+
+  /** Job is not eligible to run before this time (delay + retry backoff). */
+  @Column({ name: 'available_at', type: 'datetime', nullable: true })
+  @Index('job_available_at_idx')
+  availableAt: Date;
+
+  @Column({ name: 'locked_at', type: 'datetime', nullable: true })
+  lockedAt: Date;
+
+  @Column({ name: 'locked_by', length: 100, nullable: true })
+  lockedBy: string;
+
+  /** Optional idempotency key (e.g. schedule id + fire time) to avoid double enqueue. */
+  @Column({ name: 'dedupe_key', length: 191, nullable: true })
+  @Index('job_dedupe_key_idx')
+  dedupeKey: string;
+
+  @Column('text', { nullable: true })
+  error: string;
+
+  @CreatedAtColumn()
+  createdAt: Date;
+
+  @UpdatedAtColumn()
+  updatedAt: Date;
+
+  @Column({ name: 'completed_at', type: 'datetime', nullable: true })
+  completedAt: Date;
+}

--- a/entities/Schedule.entity.ts
+++ b/entities/Schedule.entity.ts
@@ -1,0 +1,55 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BooleanIntColumn, CreatedAtColumn, JsonColumn, UpdatedAtColumn } from '@shared/utils/entity/column-types.util';
+import { IHasUserId } from '@shared/base-entity/interface';
+import { User } from './User.entity';
+
+/**
+ * A recurring job definition. Edited as data (no redeploy). The
+ * ScheduleHeartbeatService scans due rows every minute and enqueues a Job.
+ */
+@Entity('schedules')
+export class Schedule implements IHasUserId {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('int', { name: 'user_id' })
+  @Index('schedule_user_id_idx')
+  userId: number;
+
+  @ManyToOne(() => User, { createForeignKeyConstraints: false })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Column({ length: 255 })
+  name: string;
+
+  /** Job handler key to enqueue, e.g. 'cleanup-old-jobs'. */
+  @Column({ name: 'job_type', length: 100 })
+  jobType: string;
+
+  @JsonColumn({ nullable: true })
+  payload: Record<string, any>;
+
+  /** Standard 5-field cron expression, e.g. '0 18 * * 5' (Friday 18:00). */
+  @Column({ name: 'cron_expression', length: 120 })
+  cronExpression: string;
+
+  @Column({ name: 'time_zone', length: 60, default: 'Asia/Jerusalem' })
+  timeZone: string;
+
+  @BooleanIntColumn({ default: true })
+  active: boolean;
+
+  @Column({ name: 'next_run_at', type: 'datetime', nullable: true })
+  @Index('schedule_next_run_at_idx')
+  nextRunAt: Date;
+
+  @Column({ name: 'last_run_at', type: 'datetime', nullable: true })
+  lastRunAt: Date;
+
+  @CreatedAtColumn()
+  createdAt: Date;
+
+  @UpdatedAtColumn()
+  updatedAt: Date;
+}

--- a/entities/__tests__/createSharedEntitiesImports.spec.ts
+++ b/entities/__tests__/createSharedEntitiesImports.spec.ts
@@ -2,9 +2,9 @@ import { createSharedEntitiesImports } from '../createSharedEntitiesImports';
 import userConfig from '../configs/user.config';
 
 describe('createSharedEntitiesImports', () => {
-  it('returns an array of exactly 12 items', () => {
+  it('returns an array of exactly 14 items', () => {
     const imports = createSharedEntitiesImports(userConfig);
-    expect(imports).toHaveLength(12);
+    expect(imports).toHaveLength(14);
   });
 
   it('each item is a DynamicModule (has a module property)', () => {

--- a/entities/configs/job.config.ts
+++ b/entities/configs/job.config.ts
@@ -1,0 +1,19 @@
+import { BaseEntityModuleOptions } from '@shared/base-entity/interface';
+import { Job } from '@shared/entities/Job.entity';
+
+/** Read-only monitor screen: jobs are created by code, not by users. */
+function getConfig(): BaseEntityModuleOptions {
+  return {
+    entity: Job,
+    query: {
+      join: {
+        user: { eager: false },
+      },
+    },
+    routes: {
+      only: ['getManyBase', 'getOneBase'],
+    },
+  };
+}
+
+export default getConfig();

--- a/entities/configs/schedule.config.ts
+++ b/entities/configs/schedule.config.ts
@@ -1,0 +1,11 @@
+import { BaseEntityModuleOptions } from '@shared/base-entity/interface';
+import { Schedule } from '@shared/entities/Schedule.entity';
+
+/** Full CRUD: users manage their recurring schedules as data. */
+function getConfig(): BaseEntityModuleOptions {
+  return {
+    entity: Schedule,
+  };
+}
+
+export default getConfig();

--- a/entities/createSharedEntitiesImports.ts
+++ b/entities/createSharedEntitiesImports.ts
@@ -7,13 +7,15 @@ import importFileConfig from '@shared/entities/configs/import-file.config';
 import mailAddressConfig from '@shared/utils/mail/mail-address.config';
 import phoneTemplateConfig from '@shared/entities/configs/phone-template.config';
 import phoneCampaignConfig from '@shared/entities/configs/phone-campaign.config';
+import jobConfig from '@shared/entities/configs/job.config';
+import scheduleConfig from '@shared/entities/configs/schedule.config';
 import { YemotCall } from '@shared/entities/YemotCall.entity';
 import { TextByUser } from '@shared/view-entities/TextByUser.entity';
 import { RecievedMail } from '@shared/entities/RecievedMail.entity';
 import { Image } from '@shared/entities/Image.entity';
 
 /**
- * Returns the 12 BaseEntityModule registrations that are common to all NRA projects.
+ * Returns the BaseEntityModule registrations that are common to all NRA projects.
  * Spread this into your entities module's imports array alongside project-specific registrations.
  */
 export function createSharedEntitiesImports(userConfig: BaseEntityModuleOptions) {
@@ -26,6 +28,8 @@ export function createSharedEntitiesImports(userConfig: BaseEntityModuleOptions)
     BaseEntityModule.register(mailAddressConfig),
     BaseEntityModule.register(phoneTemplateConfig),
     BaseEntityModule.register(phoneCampaignConfig),
+    BaseEntityModule.register(jobConfig),
+    BaseEntityModule.register(scheduleConfig),
     BaseEntityModule.register({ entity: YemotCall }),
     BaseEntityModule.register({ entity: TextByUser }),
     BaseEntityModule.register({ entity: RecievedMail }),

--- a/utils/jobs/__tests__/cleanup-old-jobs.handler.spec.ts
+++ b/utils/jobs/__tests__/cleanup-old-jobs.handler.spec.ts
@@ -1,0 +1,22 @@
+import { CleanupOldJobsHandler } from '../handlers/cleanup-old-jobs.handler';
+import { Job } from '@shared/entities/Job.entity';
+
+describe('CleanupOldJobsHandler', () => {
+  it('deletes terminal jobs older than the cutoff and reports the count', async () => {
+    const repo = { delete: jest.fn().mockResolvedValue({ affected: 4 }) } as any;
+    const handler = new CleanupOldJobsHandler(repo);
+    const result = await handler.handle({ payload: { days: 15 } } as unknown as Job);
+    expect(repo.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ status: expect.anything(), updatedAt: expect.anything() }),
+    );
+    expect(result.deleted).toBe(4);
+    expect(result.summary).toContain('4');
+  });
+
+  it('defaults to 30 days when payload omits days', async () => {
+    const repo = { delete: jest.fn().mockResolvedValue({ affected: 0 }) } as any;
+    const handler = new CleanupOldJobsHandler(repo);
+    const result = await handler.handle({ payload: null } as Job);
+    expect(result.summary).toContain('30 days');
+  });
+});

--- a/utils/jobs/__tests__/job-worker.service.spec.ts
+++ b/utils/jobs/__tests__/job-worker.service.spec.ts
@@ -1,0 +1,75 @@
+import { JobWorkerService } from '../job-worker.service';
+import { Job } from '@shared/entities/Job.entity';
+import { JobHandler } from '../job.types';
+
+describe('JobWorkerService', () => {
+  const OLD_ENV = process.env.WORKER_ENABLED;
+  afterEach(() => {
+    process.env.WORKER_ENABLED = OLD_ENV;
+  });
+
+  function makeJobService() {
+    return {
+      claimNext: jest.fn(),
+      markCompleted: jest.fn(),
+      markFailed: jest.fn(),
+    } as any;
+  }
+
+  it('runs a handler and marks the job completed', async () => {
+    const handler: JobHandler = { type: 'demo', handle: jest.fn().mockResolvedValue({ summary: 'ok' }) };
+    const jobService = makeJobService();
+    const worker = new JobWorkerService([handler], jobService);
+    const job = { id: 1, type: 'demo', payload: {} } as Job;
+    await worker.runJob(job);
+    expect(handler.handle).toHaveBeenCalledWith(job);
+    expect(jobService.markCompleted).toHaveBeenCalledWith(job, { summary: 'ok' });
+  });
+
+  it('fails the job when no handler is registered', async () => {
+    const jobService = makeJobService();
+    const worker = new JobWorkerService([], jobService);
+    const job = { id: 2, type: 'missing', payload: {} } as Job;
+    await worker.runJob(job);
+    expect(jobService.markFailed).toHaveBeenCalledWith(job, expect.stringContaining('missing'));
+  });
+
+  it('marks the job failed when the handler throws', async () => {
+    const handler: JobHandler = { type: 'demo', handle: jest.fn().mockRejectedValue(new Error('boom')) };
+    const jobService = makeJobService();
+    const worker = new JobWorkerService([handler], jobService);
+    const job = { id: 3, type: 'demo', payload: {}, status: 'running' } as Job;
+    await worker.runJob(job);
+    expect(jobService.markFailed).toHaveBeenCalledWith(job, 'boom');
+  });
+
+  it('sends a completion email when notifyEmail is set', async () => {
+    const handler: JobHandler = { type: 'demo', handle: jest.fn().mockResolvedValue({ url: 'http://x/f.zip' }) };
+    const jobService = makeJobService();
+    const mail = { sendMail: jest.fn().mockResolvedValue(undefined) } as any;
+    const worker = new JobWorkerService([handler], jobService, mail);
+    const job = { id: 4, type: 'demo', payload: { notifyEmail: 'a@b.com' }, status: 'completed' } as unknown as Job;
+    await worker.runJob(job);
+    expect(mail.sendMail).toHaveBeenCalledWith(expect.objectContaining({ to: 'a@b.com' }));
+  });
+
+  it('poll does nothing when worker disabled', async () => {
+    process.env.WORKER_ENABLED = 'false';
+    const jobService = makeJobService();
+    const worker = new JobWorkerService([], jobService);
+    await worker.poll();
+    expect(jobService.claimNext).not.toHaveBeenCalled();
+  });
+
+  it('poll processes claimed jobs when enabled', async () => {
+    process.env.WORKER_ENABLED = 'true';
+    const handler: JobHandler = { type: 'demo', handle: jest.fn().mockResolvedValue(null) };
+    const job = { id: 5, type: 'demo', payload: {} } as Job;
+    const jobService = makeJobService();
+    jobService.claimNext.mockResolvedValue([job]);
+    const worker = new JobWorkerService([handler], jobService);
+    await worker.poll();
+    expect(jobService.claimNext).toHaveBeenCalled();
+    expect(jobService.markCompleted).toHaveBeenCalledWith(job, null);
+  });
+});

--- a/utils/jobs/__tests__/job.service.spec.ts
+++ b/utils/jobs/__tests__/job.service.spec.ts
@@ -1,0 +1,105 @@
+import { JobService } from '../job.service';
+import { Job } from '@shared/entities/Job.entity';
+
+function makeRepo(overrides: Partial<Record<keyof any, any>> = {}) {
+  return {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+    save: jest.fn((x) => Promise.resolve(x)),
+    create: jest.fn((x) => x),
+    ...overrides,
+  } as any;
+}
+
+describe('JobService', () => {
+  describe('enqueue', () => {
+    it('creates a pending job with defaults', async () => {
+      const repo = makeRepo();
+      const service = new JobService(repo);
+      const job = await service.enqueue(7, 'cleanup-old-jobs', { days: 10 });
+      expect(repo.save).toHaveBeenCalled();
+      expect(job.userId).toBe(7);
+      expect(job.type).toBe('cleanup-old-jobs');
+      expect(job.status).toBe('pending');
+      expect(job.maxAttempts).toBe(3);
+      expect(job.payload).toEqual({ days: 10 });
+      expect(job.availableAt).toBeInstanceOf(Date);
+    });
+
+    it('skips enqueue when a non-terminal job shares the dedupeKey', async () => {
+      const repo = makeRepo({ findOne: jest.fn().mockResolvedValue({ id: 1, status: 'pending' }) });
+      const service = new JobService(repo);
+      const job = await service.enqueue(7, 'x', {}, { dedupeKey: 'k' });
+      expect(job).toBeNull();
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('enqueues when the dedupeKey job is terminal', async () => {
+      const repo = makeRepo({ findOne: jest.fn().mockResolvedValue({ id: 1, status: 'completed' }) });
+      const service = new JobService(repo);
+      const job = await service.enqueue(7, 'x', {}, { dedupeKey: 'k' });
+      expect(job).not.toBeNull();
+      expect(repo.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('claimNext', () => {
+    it('claims only rows whose conditional update wins', async () => {
+      const candidates = [
+        { id: 1, attempts: 0 },
+        { id: 2, attempts: 1 },
+      ] as Job[];
+      const repo = makeRepo({
+        find: jest.fn().mockResolvedValue(candidates),
+        update: jest
+          .fn()
+          .mockResolvedValueOnce({ affected: 1 })
+          .mockResolvedValueOnce({ affected: 0 }),
+      });
+      const service = new JobService(repo);
+      const claimed = await service.claimNext('worker-1', 5);
+      expect(claimed).toHaveLength(1);
+      expect(claimed[0].id).toBe(1);
+      expect(claimed[0].status).toBe('running');
+      expect(claimed[0].lockedBy).toBe('worker-1');
+      expect(claimed[0].attempts).toBe(1);
+    });
+  });
+
+  describe('markCompleted', () => {
+    it('sets completed state and result', async () => {
+      const repo = makeRepo();
+      const service = new JobService(repo);
+      const job = { attempts: 1 } as Job;
+      await service.markCompleted(job, { summary: 'ok' });
+      expect(job.status).toBe('completed');
+      expect(job.progress).toBe(100);
+      expect(job.result).toEqual({ summary: 'ok' });
+      expect(job.completedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('markFailed', () => {
+    it('reschedules with backoff while attempts remain', async () => {
+      const repo = makeRepo();
+      const service = new JobService(repo);
+      const job = { attempts: 1, maxAttempts: 3, status: 'running' } as Job;
+      const before = Date.now();
+      await service.markFailed(job, 'boom');
+      expect(job.status).toBe('pending');
+      expect(job.lockedBy).toBeNull();
+      expect(job.availableAt.getTime()).toBeGreaterThan(before);
+      expect(job.error).toBe('boom');
+    });
+
+    it('marks terminally failed at maxAttempts', async () => {
+      const repo = makeRepo();
+      const service = new JobService(repo);
+      const job = { attempts: 3, maxAttempts: 3, status: 'running' } as Job;
+      await service.markFailed(job, 'boom');
+      expect(job.status).toBe('failed');
+      expect(job.completedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/utils/jobs/__tests__/schedule-heartbeat.service.spec.ts
+++ b/utils/jobs/__tests__/schedule-heartbeat.service.spec.ts
@@ -1,0 +1,70 @@
+import { ScheduleHeartbeatService } from '../schedule-heartbeat.service';
+import { Schedule } from '@shared/entities/Schedule.entity';
+
+describe('ScheduleHeartbeatService', () => {
+  const OLD_ENV = process.env.WORKER_ENABLED;
+  afterEach(() => {
+    process.env.WORKER_ENABLED = OLD_ENV;
+  });
+
+  function makeRepo(schedules: Partial<Schedule>[]) {
+    return {
+      find: jest.fn().mockResolvedValue(schedules),
+      save: jest.fn((x) => Promise.resolve(x)),
+    } as any;
+  }
+
+  it('does nothing when worker disabled', async () => {
+    process.env.WORKER_ENABLED = 'false';
+    const repo = makeRepo([]);
+    const jobService = { enqueue: jest.fn() } as any;
+    const service = new ScheduleHeartbeatService(repo, jobService);
+    await service.tick();
+    expect(repo.find).not.toHaveBeenCalled();
+  });
+
+  it('initializes nextRunAt without enqueueing when null', async () => {
+    process.env.WORKER_ENABLED = 'true';
+    const schedule: Partial<Schedule> = { id: 1, cronExpression: '0 18 * * 5', timeZone: 'Asia/Jerusalem', nextRunAt: null };
+    const repo = makeRepo([schedule]);
+    const jobService = { enqueue: jest.fn() } as any;
+    const service = new ScheduleHeartbeatService(repo, jobService);
+    await service.tick();
+    expect(jobService.enqueue).not.toHaveBeenCalled();
+    expect(schedule.nextRunAt).toBeInstanceOf(Date);
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  it('enqueues due schedules and advances nextRunAt', async () => {
+    process.env.WORKER_ENABLED = 'true';
+    const past = new Date(Date.now() - 60_000);
+    const schedule: Partial<Schedule> = {
+      id: 2,
+      userId: 9,
+      jobType: 'cleanup-old-jobs',
+      payload: { days: 30 },
+      cronExpression: '*/5 * * * *',
+      timeZone: 'Asia/Jerusalem',
+      nextRunAt: past,
+    };
+    const repo = makeRepo([schedule]);
+    const jobService = { enqueue: jest.fn().mockResolvedValue({ id: 100 }) } as any;
+    const service = new ScheduleHeartbeatService(repo, jobService);
+    await service.tick();
+    expect(jobService.enqueue).toHaveBeenCalledWith(
+      9,
+      'cleanup-old-jobs',
+      { days: 30 },
+      expect.objectContaining({ dedupeKey: expect.stringContaining('sched-2-') }),
+    );
+    expect(schedule.nextRunAt.getTime()).toBeGreaterThan(past.getTime());
+    expect(schedule.lastRunAt).toBeInstanceOf(Date);
+  });
+
+  it('computeNext returns a future date from the cron expression', () => {
+    const repo = makeRepo([]);
+    const service = new ScheduleHeartbeatService(repo, { enqueue: jest.fn() } as any);
+    const next = service.computeNext({ cronExpression: '*/5 * * * *', timeZone: 'Asia/Jerusalem' } as Schedule);
+    expect(next.getTime()).toBeGreaterThan(Date.now());
+  });
+});

--- a/utils/jobs/__tests__/user-data-export.handler.spec.ts
+++ b/utils/jobs/__tests__/user-data-export.handler.spec.ts
@@ -1,0 +1,53 @@
+import { UserDataExportHandler } from '../handlers/user-data-export.handler';
+import { Job } from '@shared/entities/Job.entity';
+
+jest.mock('@shared/utils/report/data-to-excel.generator', () => ({
+  DataToExcelReportGenerator: class {
+    constructor(public getName: any) {}
+    async getFileBuffer() {
+      return Buffer.from('xlsx');
+    }
+  },
+}));
+
+describe('UserDataExportHandler', () => {
+  function makeDataSource(metas: any[], rowsByTable: Record<string, any[]>) {
+    return {
+      entityMetadatas: metas,
+      getRepository: (target: any) => ({
+        find: jest.fn().mockResolvedValue(rowsByTable[target] ?? []),
+      }),
+    } as any;
+  }
+
+  it('zips a sheet per user-owned entity and returns base64 when no S3', async () => {
+    const metas = [
+      { target: 'Student', tableName: 'student', columns: [{ propertyName: 'userId' }, { propertyName: 'name' }] },
+      { target: 'Global', tableName: 'global', columns: [{ propertyName: 'id' }] }, // no userId → skipped
+    ];
+    const dataSource = makeDataSource(metas, { Student: [{ userId: 5, name: 'A' }] });
+    const handler = new UserDataExportHandler(dataSource);
+    const result = await handler.handle({ userId: 5, payload: {} } as Job);
+    expect(result.format).toBe('zip');
+    expect(result.data).toBeDefined();
+    expect(result.s3Key).toBeUndefined();
+    expect(result.summary).toContain('1 tables');
+  });
+
+  it('uploads to S3 and returns key when bucket configured', async () => {
+    const OLD = process.env.S3_BUCKET;
+    process.env.S3_BUCKET = 'my-bucket';
+    const metas = [{ target: 'Student', tableName: 'student', columns: [{ propertyName: 'userId' }] }];
+    const dataSource = makeDataSource(metas, { Student: [{ userId: 5 }] });
+    const fileStore = {
+      buildKey: jest.fn().mockReturnValue('data-export/x.zip'),
+      upload: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const handler = new UserDataExportHandler(dataSource, fileStore);
+    const result = await handler.handle({ userId: 5, payload: {} } as Job);
+    expect(fileStore.upload).toHaveBeenCalled();
+    expect(result.s3Key).toBe('data-export/x.zip');
+    expect(result.data).toBeUndefined();
+    process.env.S3_BUCKET = OLD;
+  });
+});

--- a/utils/jobs/handlers/cleanup-old-jobs.handler.ts
+++ b/utils/jobs/handlers/cleanup-old-jobs.handler.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, LessThan, Repository } from 'typeorm';
+import { Job } from '@shared/entities/Job.entity';
+import { JobHandler, JobResult } from '../job.types';
+
+/**
+ * Retention: delete terminal jobs older than `payload.days` (default 30).
+ * Pair with a Schedule row to keep the jobs table from growing forever.
+ */
+@Injectable()
+export class CleanupOldJobsHandler implements JobHandler {
+  readonly type = 'cleanup-old-jobs';
+
+  constructor(@InjectRepository(Job) private readonly repo: Repository<Job>) {}
+
+  async handle(job: Job): Promise<JobResult> {
+    const days = Number(job.payload?.days) || 30;
+    const cutoff = new Date(Date.now() - days * 86_400_000);
+    const res = await this.repo.delete({
+      status: In(['completed', 'failed', 'cancelled']),
+      updatedAt: LessThan(cutoff),
+    });
+    return { summary: `deleted ${res.affected ?? 0} jobs older than ${days} days`, deleted: res.affected ?? 0 };
+  }
+}

--- a/utils/jobs/handlers/user-data-export.handler.ts
+++ b/utils/jobs/handlers/user-data-export.handler.ts
@@ -1,0 +1,70 @@
+import { Injectable, Optional } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import * as JSZip from 'jszip';
+import { Job } from '@shared/entities/Job.entity';
+import { DataToExcelReportGenerator } from '@shared/utils/report/data-to-excel.generator';
+import { S3FileStoreService } from '@shared/utils/s3/s3-file-store.service';
+import { JobHandler, JobResult } from '../job.types';
+
+/**
+ * Full data takeout: one Excel sheet per user-owned entity, zipped. Large files
+ * go to S3 (when S3_BUCKET is set) and are delivered by link; otherwise the zip
+ * is returned base64 for direct download via the async-download button.
+ * Covers the "move to another platform" example.
+ */
+@Injectable()
+export class UserDataExportHandler implements JobHandler {
+  readonly type = 'user-data-export';
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    @Optional() private readonly fileStore?: S3FileStoreService,
+  ) {}
+
+  async handle(job: Job): Promise<JobResult> {
+    const zip = new JSZip();
+    let sheets = 0;
+
+    for (const meta of this.dataSource.entityMetadatas) {
+      const hasUserId = meta.columns.some((c) => c.propertyName === 'userId');
+      if (!hasUserId) {
+        continue;
+      }
+      const rows = await this.dataSource.getRepository(meta.target).find({ where: { userId: job.userId } as any });
+      if (!rows.length) {
+        continue;
+      }
+      const headerRow = meta.columns.map((c) => c.propertyName);
+      const formattedData = rows.map((row) => headerRow.map((prop) => formatCell(row[prop])));
+      const generator = new DataToExcelReportGenerator(() => meta.tableName);
+      const buffer = await generator.getFileBuffer({ headerRow, formattedData, sheetName: meta.tableName });
+      zip.file(`${meta.tableName}.xlsx`, buffer);
+      sheets++;
+    }
+
+    const zipBuffer: Buffer = await zip.generateAsync({ type: 'nodebuffer' });
+    const filename = `data-export-${job.userId}.zip`;
+
+    if (this.fileStore && process.env.S3_BUCKET) {
+      const key = this.fileStore.buildKey('data-export', job.userId, 'zip');
+      await this.fileStore.upload(key, zipBuffer, 'application/zip');
+      return { summary: `exported ${sheets} tables`, s3Key: key, filename, format: 'zip' };
+    }
+
+    return { summary: `exported ${sheets} tables`, data: zipBuffer.toString('base64'), filename, format: 'zip' };
+  }
+}
+
+function formatCell(value: any): string | number {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return value as string | number;
+}

--- a/utils/jobs/job-worker.service.ts
+++ b/utils/jobs/job-worker.service.ts
@@ -1,0 +1,103 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { hostname } from 'os';
+import { Job } from '@shared/entities/Job.entity';
+import { MailSendService } from '@shared/utils/mail/mail-send.service';
+import { JobService } from './job.service';
+import { JOB_HANDLER, JobHandler, JobResult } from './job.types';
+
+const POLL_MS = Number(process.env.JOB_POLL_MS) || 5000;
+const BATCH = Number(process.env.JOB_WORKER_BATCH) || 5;
+
+/**
+ * Polls the jobs table and runs due jobs. Disabled by default; set
+ * WORKER_ENABLED=true on the instance(s) that should process jobs (typically a
+ * dedicated worker process, or the single API container for small deployments).
+ */
+@Injectable()
+export class JobWorkerService {
+  private readonly logger = new Logger(JobWorkerService.name);
+  private readonly handlers = new Map<string, JobHandler>();
+  private readonly workerId = `${hostname()}:${process.pid}`;
+  private busy = false;
+
+  constructor(
+    @Inject(JOB_HANDLER) handlers: JobHandler[],
+    private readonly jobService: JobService,
+    @Optional() private readonly mailSendService?: MailSendService,
+  ) {
+    for (const handler of handlers ?? []) {
+      this.handlers.set(handler.type, handler);
+    }
+  }
+
+  static isEnabled(): boolean {
+    return process.env.WORKER_ENABLED === 'true';
+  }
+
+  @Interval('job-worker', POLL_MS)
+  async poll(): Promise<void> {
+    if (!JobWorkerService.isEnabled() || this.busy) {
+      return;
+    }
+    this.busy = true;
+    try {
+      await this.processBatch();
+    } catch (err) {
+      this.logger.error(`worker poll failed: ${err?.message}`);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  async processBatch(): Promise<void> {
+    const jobs = await this.jobService.claimNext(this.workerId, BATCH);
+    for (const job of jobs) {
+      await this.runJob(job);
+    }
+  }
+
+  async runJob(job: Job): Promise<void> {
+    const handler = this.handlers.get(job.type);
+    if (!handler) {
+      await this.jobService.markFailed(job, `no handler registered for type "${job.type}"`);
+      return;
+    }
+    try {
+      const result = (await handler.handle(job)) || null;
+      await this.jobService.markCompleted(job, result);
+      await this.notify(job, result);
+    } catch (err) {
+      this.logger.error(`job ${job.id} (${job.type}) failed: ${err?.message}`);
+      await this.jobService.markFailed(job, err?.message ?? 'unknown error');
+      if (job.status === 'failed') {
+        await this.notify(job, null);
+      }
+    }
+  }
+
+  private async notify(job: Job, result: JobResult | null): Promise<void> {
+    const to = job.payload?.notifyEmail;
+    if (!to || !this.mailSendService) {
+      return;
+    }
+    try {
+      if (job.status === 'completed') {
+        const link = result?.url ? `<p><a href="${result.url}">${result.url}</a></p>` : '';
+        await this.mailSendService.sendMail({
+          to,
+          subject: `המשימה "${job.type}" הושלמה`,
+          html: `<div>המשימה הושלמה בהצלחה.</div>${result?.summary ? `<div>${result.summary}</div>` : ''}${link}`,
+        });
+      } else {
+        await this.mailSendService.sendMail({
+          to,
+          subject: `המשימה "${job.type}" נכשלה`,
+          html: `<div>המשימה נכשלה: ${job.error ?? ''}</div>`,
+        });
+      }
+    } catch (err) {
+      this.logger.error(`failed to send notification for job ${job.id}: ${err?.message}`);
+    }
+  }
+}

--- a/utils/jobs/job.service.ts
+++ b/utils/jobs/job.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import { Job, JobStatus } from '@shared/entities/Job.entity';
+import { JobResult } from './job.types';
+
+export interface EnqueueOptions {
+  availableAt?: Date;
+  maxAttempts?: number;
+  /** Idempotency key: enqueue is skipped if a pending/running job already has it. */
+  dedupeKey?: string;
+}
+
+const TERMINAL: JobStatus[] = ['completed', 'failed', 'cancelled'];
+
+@Injectable()
+export class JobService {
+  constructor(@InjectRepository(Job) public readonly repo: Repository<Job>) {}
+
+  async enqueue(userId: number, type: string, payload?: Record<string, any>, opts: EnqueueOptions = {}): Promise<Job | null> {
+    if (opts.dedupeKey) {
+      const existing = await this.repo.findOne({ where: { dedupeKey: opts.dedupeKey } });
+      if (existing && !TERMINAL.includes(existing.status)) {
+        return null;
+      }
+    }
+    const job = this.repo.create({
+      userId,
+      type,
+      status: 'pending',
+      payload: payload ?? null,
+      attempts: 0,
+      maxAttempts: opts.maxAttempts ?? 3,
+      availableAt: opts.availableAt ?? new Date(),
+      dedupeKey: opts.dedupeKey ?? null,
+    });
+    return this.repo.save(job);
+  }
+
+  /**
+   * Atomically claim up to `batch` due jobs for a worker. The conditional
+   * UPDATE on status='pending' guarantees only one worker wins each row, so no
+   * SKIP LOCKED / MySQL-8 requirement. Fine for low-concurrency workloads.
+   */
+  async claimNext(workerId: string, batch: number): Promise<Job[]> {
+    const now = new Date();
+    const candidates = await this.repo.find({
+      where: { status: 'pending', availableAt: LessThanOrEqual(now) },
+      order: { availableAt: 'ASC', id: 'ASC' },
+      take: batch,
+    });
+    const claimed: Job[] = [];
+    for (const candidate of candidates) {
+      const res = await this.repo.update(
+        { id: candidate.id, status: 'pending' },
+        { status: 'running', lockedAt: now, lockedBy: workerId, attempts: candidate.attempts + 1 },
+      );
+      if (res.affected === 1) {
+        candidate.status = 'running';
+        candidate.lockedAt = now;
+        candidate.lockedBy = workerId;
+        candidate.attempts = candidate.attempts + 1;
+        claimed.push(candidate);
+      }
+    }
+    return claimed;
+  }
+
+  async markCompleted(job: Job, result?: JobResult | null): Promise<void> {
+    job.status = 'completed';
+    job.result = result ?? null;
+    job.progress = 100;
+    job.completedAt = new Date();
+    job.error = null;
+    await this.repo.save(job);
+  }
+
+  /**
+   * Fail with retry: reschedule with exponential backoff until maxAttempts,
+   * then mark terminally failed.
+   */
+  async markFailed(job: Job, error: string): Promise<void> {
+    job.error = (error ?? '').slice(0, 5000);
+    if (job.attempts >= job.maxAttempts) {
+      job.status = 'failed';
+      job.completedAt = new Date();
+    } else {
+      job.status = 'pending';
+      job.lockedAt = null;
+      job.lockedBy = null;
+      job.availableAt = new Date(Date.now() + this.backoffMs(job.attempts));
+    }
+    await this.repo.save(job);
+  }
+
+  private backoffMs(attempts: number): number {
+    // 30s, 60s, 120s, ... capped at 30min
+    return Math.min(30_000 * 2 ** (attempts - 1), 30 * 60_000);
+  }
+}

--- a/utils/jobs/job.types.ts
+++ b/utils/jobs/job.types.ts
@@ -1,0 +1,26 @@
+import { Job } from '@shared/entities/Job.entity';
+
+/** DI token collecting all registered job handlers (multi-provider). */
+export const JOB_HANDLER = Symbol('JOB_HANDLER');
+
+export interface JobResult {
+  /** Base64 file for direct client download (small files). */
+  data?: string;
+  /** S3 key / URL for large files delivered out-of-band. */
+  url?: string;
+  s3Key?: string;
+  filename?: string;
+  format?: string;
+  summary?: string;
+  [key: string]: any;
+}
+
+/**
+ * A unit of background work. Handlers are Nest providers registered via
+ * JobsModule; they receive their own dependencies through DI.
+ */
+export interface JobHandler {
+  /** Unique key matched against Job.type. */
+  readonly type: string;
+  handle(job: Job): Promise<JobResult | void>;
+}

--- a/utils/jobs/jobs.module.ts
+++ b/utils/jobs/jobs.module.ts
@@ -1,0 +1,49 @@
+import { DynamicModule, Module, Provider, Type } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Job } from '@shared/entities/Job.entity';
+import { Schedule } from '@shared/entities/Schedule.entity';
+import { JobService } from './job.service';
+import { JobWorkerService } from './job-worker.service';
+import { ScheduleHeartbeatService } from './schedule-heartbeat.service';
+import { JOB_HANDLER, JobHandler } from './job.types';
+import { CleanupOldJobsHandler } from './handlers/cleanup-old-jobs.handler';
+import { UserDataExportHandler } from './handlers/user-data-export.handler';
+
+/** Handlers shipped for every project. */
+const SHARED_HANDLERS: Type<JobHandler>[] = [CleanupOldJobsHandler, UserDataExportHandler];
+
+export interface JobsModuleOptions {
+  /** Project-specific handlers to register alongside the shared ones. */
+  handlers?: Type<JobHandler>[];
+}
+
+/**
+ * Async worker infrastructure: durable jobs table + poll worker + data-driven
+ * schedule heartbeat. Import once via `JobsModule.forRoot()` in the app module.
+ * MailSendService and S3FileStoreService come from their global modules.
+ */
+@Module({})
+export class JobsModule {
+  static forRoot(options: JobsModuleOptions = {}): DynamicModule {
+    const handlerClasses = [...SHARED_HANDLERS, ...(options.handlers ?? [])];
+    const handlerProviders: Provider[] = handlerClasses.map((cls) => ({
+      provide: JOB_HANDLER,
+      useExisting: cls,
+      multi: true,
+    }));
+
+    return {
+      module: JobsModule,
+      imports: [ScheduleModule.forRoot(), TypeOrmModule.forFeature([Job, Schedule])],
+      providers: [
+        JobService,
+        JobWorkerService,
+        ScheduleHeartbeatService,
+        ...handlerClasses,
+        ...handlerProviders,
+      ],
+      exports: [JobService],
+    };
+  }
+}

--- a/utils/jobs/jobs.module.ts
+++ b/utils/jobs/jobs.module.ts
@@ -27,11 +27,11 @@ export interface JobsModuleOptions {
 export class JobsModule {
   static forRoot(options: JobsModuleOptions = {}): DynamicModule {
     const handlerClasses = [...SHARED_HANDLERS, ...(options.handlers ?? [])];
-    const handlerProviders: Provider[] = handlerClasses.map((cls) => ({
+    const handlerAggregator: Provider = {
       provide: JOB_HANDLER,
-      useExisting: cls,
-      multi: true,
-    }));
+      useFactory: (...handlers: JobHandler[]) => handlers,
+      inject: handlerClasses,
+    };
 
     return {
       module: JobsModule,
@@ -41,7 +41,7 @@ export class JobsModule {
         JobWorkerService,
         ScheduleHeartbeatService,
         ...handlerClasses,
-        ...handlerProviders,
+        handlerAggregator,
       ],
       exports: [JobService],
     };

--- a/utils/jobs/schedule-heartbeat.service.ts
+++ b/utils/jobs/schedule-heartbeat.service.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import * as parser from 'cron-parser';
+import { Schedule } from '@shared/entities/Schedule.entity';
+import { JobService } from './job.service';
+import { JobWorkerService } from './job-worker.service';
+
+/**
+ * Single per-minute heartbeat that turns recurring Schedule rows into Jobs.
+ * All scheduling lives in data (the schedules table), so times can change
+ * without a redeploy. Runs only on the worker instance to avoid double-firing
+ * when the API is scaled to multiple replicas.
+ */
+@Injectable()
+export class ScheduleHeartbeatService {
+  private readonly logger = new Logger(ScheduleHeartbeatService.name);
+
+  constructor(
+    @InjectRepository(Schedule) private readonly repo: Repository<Schedule>,
+    private readonly jobService: JobService,
+  ) {}
+
+  @Cron('* * * * *')
+  async tick(): Promise<void> {
+    if (!JobWorkerService.isEnabled()) {
+      return;
+    }
+    const now = new Date();
+    const schedules = await this.repo.find({ where: { active: true } });
+    for (const schedule of schedules) {
+      try {
+        if (!schedule.nextRunAt) {
+          schedule.nextRunAt = this.computeNext(schedule);
+          await this.repo.save(schedule);
+          continue;
+        }
+        if (schedule.nextRunAt <= now) {
+          const dedupeKey = `sched-${schedule.id}-${schedule.nextRunAt.toISOString()}`;
+          await this.jobService.enqueue(schedule.userId, schedule.jobType, schedule.payload, { dedupeKey });
+          schedule.lastRunAt = now;
+          schedule.nextRunAt = this.computeNext(schedule);
+          await this.repo.save(schedule);
+        }
+      } catch (err) {
+        this.logger.error(`schedule ${schedule.id} failed: ${err?.message}`);
+      }
+    }
+  }
+
+  computeNext(schedule: Schedule): Date {
+    return parser
+      .parseExpression(schedule.cronExpression, { tz: schedule.timeZone || 'Asia/Jerusalem', currentDate: new Date() })
+      .next()
+      .toDate();
+  }
+}


### PR DESCRIPTION
## What

MySQL-backed durable job queue with a poll worker and a data-driven schedule heartbeat. Shared across all NRA projects (event, student, teacher, etc.) via the `server/shared` submodule.

## Why

Need a general mechanism for background/async work: heavy on-demand jobs (e.g. per-student PDF report → email, full data export → zip) and recurring jobs (e.g. Friday sweep: threshold report, mark inactive, purge old data, phone campaign). No new infra required — reuses existing MySQL, MailSendService, S3, and report generators.

## Design

- **`Job` entity** — durable execution row: `type`, `status` (pending/running/completed/failed/cancelled), `payload`, `result`, `attempts`/`maxAttempts`, `availableAt` (delay + retry backoff), `lockedBy`, `dedupeKey`.
- **`Schedule` entity** — recurring definition edited as data (no redeploy): `cronExpression`, `timeZone`, `active`, `nextRunAt`.
- **`JobService`** — `enqueue` (with dedupe), atomic **conditional-update claim** (no `SKIP LOCKED` / MySQL-8 requirement), retry with exponential backoff.
- **`JobWorkerService`** — poll loop gated by `WORKER_ENABLED`, dispatches to registered handlers, sends completion/failure email when `payload.notifyEmail` set.
- **`ScheduleHeartbeatService`** — one `@Cron('* * * * *')` scans due schedules and enqueues jobs; computes `nextRunAt` via `cron-parser`.
- **`JobsModule.forRoot({ handlers })`** — wired into the base app module; projects add their own handlers.
- **Shipped handlers**: `cleanup-old-jobs` (retention) and `user-data-export` (zip takeout → S3 link or base64).

`Job` (read-only) and `Schedule` (CRUD) registered in `createSharedEntitiesImports`.

## Testing

- 21 unit tests across service / worker / heartbeat / handlers — all passing.
- `tsc --noEmit` clean.
- Migration DDL validated against a real MySQL (MariaDB 10.11): tables + all indexes created, conditional-claim `UPDATE` verified.

## Notes / open tradeoffs

- Worker is **opt-in** (`WORKER_ENABLED=true`); run it on a dedicated process in prod or the single API container for small deployments. Poll interval `JOB_POLL_MS`, batch `JOB_WORKER_BATCH`.
- Heartbeat also gated by `WORKER_ENABLED` so it fires once even if the API scales to multiple replicas.
- Conditional-update claim is intended for low-concurrency; swap to BullMQ+Redis if throughput demands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dEYULADLgGNfZ4nv6gz8s

---
_Generated by [Claude Code](https://claude.ai/code/session_011dEYULADLgGNfZ4nv6gz8s)_